### PR TITLE
fix: align HTTP spans with latest OpenTelemetry semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,8 +213,9 @@ mod tests {
 #### Modifying span attributes
 
 1. Update `AxumOtelSpanCreator::make_span` in `crates/axum-otel/src/make_span.rs`
-2. Ensure compliance with OpenTelemetry semantic conventions
-3. Update documentation with new attributes
+2. Ensure compliance with [OpenTelemetry HTTP traces](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) (see `axum_otel` crate docs on docs.rs for the attribute migration table and `CHANGELOG.md` for breaking renames)
+3. Keep `tracing-otel-extra` `make_request_span` (`crates/tracing-otel/src/http/span.rs`) in sync when changing shared HTTP field names
+4. Update documentation with new attributes
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The goal of axum-otel is to **reduce boilerplate and decision-making** when sett
 * **Structured Logging** - Rich structured logging with customizable fields, making logs searchable and analyzable
 * **File Logging & Rotation** - Built-in file appender with automatic log rotation, perfect for production deployments
 * **Builder Pattern API** - Intuitive builder pattern for configuration, reducing boilerplate code
-* **HTTP Semantic Attributes** - Automatically captures comprehensive HTTP attributes (method, route, client_ip, host, user_agent, request_id, trace_id) following OpenTelemetry semantic conventions
+* **HTTP Semantic Attributes** - Request spans capture method, route, URL parts, protocol, `server.address`, `client.address` (with `ConnectInfo`), `user_agent.original`, `request_id`, and `trace_id`, aligned with [OpenTelemetry HTTP traces](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)
 * **Metrics Collection** - Built-in HTTP metrics instrumentation with OTLP export support
 * **Environment Configuration** - Support for standard OpenTelemetry environment variables for flexible deployment configuration
 

--- a/crates/axum-otel/CHANGELOG.md
+++ b/crates/axum-otel/CHANGELOG.md
@@ -2,16 +2,20 @@
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- HTTP span attributes were renamed to align with [OpenTelemetry HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/): `http.host` → `server.address`, `http.user_agent` → `user_agent.original`, `http.client_ip` → `client.address` (when `[ConnectInfo](https://docs.rs/axum/latest/axum/extract/struct.ConnectInfo.html)` is present). Update dashboards, alerts, and sampling rules that referenced the old attribute keys.
+- `http.response.status_code` is recorded as an integer (OpenTelemetry `int`), not a string.
+
+### 📚 Documentation
+
+- Expand crate-level documentation with attribute migration and links to the OpenTelemetry HTTP spec.
 
 ## [0.31.5](https://github.com/iamnivekx/tracing-otel-extra/compare/axum-otel-v0.31.4...axum-otel-v0.31.5)
-
-
-
 
 ### 🚜 Refactor
 
 - Reorganize imports and simplify shutdown logic in tracing modules - ([0f95108](https://github.com/iamnivekx/tracing-otel-extra/commit/0f951082ae571380fef1c626855271d1ab74794a))
-
 
 ### ⚙️ Miscellaneous Tasks
 

--- a/crates/axum-otel/README.md
+++ b/crates/axum-otel/README.md
@@ -9,6 +9,7 @@ A structured logging middleware for Axum web framework that integrates with Open
 - Request tracing
 - Metrics collection
 - Customizable span attributes
+- [OpenTelemetry HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) for span attributes (see [crate docs](https://docs.rs/axum-otel) for migration from older field names)
 
 ## Installation
 
@@ -79,9 +80,9 @@ async fn main() {
 
 ## Examples
 
-Check out the [examples](https://github.com/iamnivekx/axum-otel/tree/main/examples) directory for more usage examples:
+Check out the [examples](https://github.com/iamnivekx/tracing-otel-extra/tree/main/examples) directory for more usage examples:
 
-- [Basic OpenTelemetry integration](https://github.com/iamnivekx/axum-otel/tree/main/examples/otel)
+- [Basic OpenTelemetry integration](https://github.com/iamnivekx/tracing-otel-extra/tree/main/examples/otel)
 
 ## Documentation
 

--- a/crates/axum-otel/src/lib.rs
+++ b/crates/axum-otel/src/lib.rs
@@ -56,7 +56,20 @@
 //! - [`AxumOtelOnResponse`] - Records response status and latency
 //! - [`AxumOtelOnFailure`] - Handles error cases and updates span status
 //!
-//! See the [examples](https://github.com/iamnivekx/axum-otel/tree/main/examples) directory for complete examples.
+//! ## HTTP span attributes
+//!
+//! Field names follow the [OpenTelemetry HTTP traces](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)
+//! semantic conventions where applicable. If you upgrade from older releases, update queries and dashboards:
+//!
+//! | Previous attribute | Replacement |
+//! |--------------------|-------------|
+//! | `http.host` | `server.address` |
+//! | `http.user_agent` | `user_agent.original` |
+//! | `http.client_ip` | `client.address` |
+//!
+//! `http.response.status_code` is recorded as an **integer** when the response is sent ([`AxumOtelOnResponse`]).
+//!
+//! See the [examples](https://github.com/iamnivekx/tracing-otel-extra/tree/main/examples) directory for complete examples.
 //!
 mod make_span;
 mod on_failure;

--- a/crates/axum-otel/src/make_span.rs
+++ b/crates/axum-otel/src/make_span.rs
@@ -18,10 +18,15 @@ use tracing_otel_extra::{
 ///
 /// This span creator automatically adds the following attributes to each span:
 ///
-/// - `http.method`: The HTTP method
+/// - `http.request.method`: The HTTP method
 /// - `http.route`: The matched route
 /// - `http.client_ip`: The client's IP address
 /// - `http.host`: The Host header
+/// - `network.protocol.name`: The network protocol name
+/// - `network.protocol.version`: The network protocol version
+/// - `url.path`: The request path
+/// - `url.query`: The request query string
+/// - `url.scheme`: The request scheme
 /// - `http.user_agent`: The User-Agent header
 /// - `request_id`: A unique request identifier
 /// - `trace_id`: The OpenTelemetry trace ID
@@ -86,21 +91,50 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
         let span = dyn_span!(
             self.level,
             "request",
-            http.client_ip = client_ip,
-            http.versions = ?request.version(),
-            http.host = ?fields::extract_host(request),
-            http.method = ?fields::extract_http_method(request),
-            http.route = http_route,
-            http.scheme = ?fields::extract_http_scheme(request),
-            http.status_code = Empty,
-            http.target = request.uri().path_and_query().map(|p| p.as_str()),
-            http.user_agent = ?fields::extract_user_agent(request),
+            http.client_ip = Empty,
+            http.host = Empty,
+            http.request.method = %fields::extract_http_method(request),
+            http.route = Empty,
+            http.response.status_code = Empty,
+            http.user_agent = Empty,
+            network.protocol.name = fields::extract_network_protocol_name(request),
+            network.protocol.version = Empty,
             otel.name = span_name,
             otel.kind = ?SpanKind::Server,
             otel.status_code = Empty,
-            request_id = %fields::extract_request_id(request),
-            trace_id = Empty
+            otel.status_description = Empty,
+            request_id = Empty,
+            trace_id = Empty,
+            url.path = fields::extract_url_path(request),
+            url.query = Empty,
+            url.scheme = Empty
         );
+
+        if let Some(client_ip) = client_ip {
+            span.record("http.client_ip", client_ip);
+        }
+        if let Some(host) = fields::extract_host(request) {
+            span.record("http.host", host);
+        }
+        if let Some(route) = http_route {
+            span.record("http.route", route);
+        }
+        if let Some(user_agent) = fields::extract_user_agent(request) {
+            span.record("http.user_agent", user_agent);
+        }
+        if let Some(version) = fields::extract_network_protocol_version(request) {
+            span.record("network.protocol.version", version);
+        }
+        if let Some(request_id) = fields::extract_request_id(request) {
+            span.record("request_id", request_id);
+        }
+        if let Some(query) = fields::extract_url_query(request) {
+            span.record("url.query", query);
+        }
+        if let Some(scheme) = fields::extract_url_scheme(request) {
+            span.record("url.scheme", scheme);
+        }
+
         context::set_otel_parent(request.headers(), &span);
         span
     }

--- a/crates/axum-otel/src/make_span.rs
+++ b/crates/axum-otel/src/make_span.rs
@@ -133,7 +133,7 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             span.record("url.scheme", scheme);
         }
         if let Some(peer) = peer {
-            span.record("client.address", peer.ip().to_string());
+            span.record("client.address", tracing::field::display(peer.ip()));
         }
 
         context::set_otel_parent(request.headers(), &span);

--- a/crates/axum-otel/src/make_span.rs
+++ b/crates/axum-otel/src/make_span.rs
@@ -20,14 +20,15 @@ use tracing_otel_extra::{
 ///
 /// - `http.request.method`: The HTTP method
 /// - `http.route`: The matched route
-/// - `http.client_ip`: The client's IP address
-/// - `http.host`: The Host header
+/// - `http.response.status_code`: The response status code (recorded when the response is sent)
+/// - `server.address`: The `Host` header (OpenTelemetry [`server.address`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/server/))
+/// - `client.address`: The client IP when [`ConnectInfo`] is available (OpenTelemetry [`client.address`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/client/))
 /// - `network.protocol.name`: The network protocol name
 /// - `network.protocol.version`: The network protocol version
 /// - `url.path`: The request path
 /// - `url.query`: The request query string
 /// - `url.scheme`: The request scheme
-/// - `http.user_agent`: The User-Agent header
+/// - `user_agent.original`: The `User-Agent` header
 /// - `request_id`: A unique request identifier
 /// - `trace_id`: The OpenTelemetry trace ID
 ///
@@ -78,10 +79,10 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             .get::<MatchedPath>()
             .map(|p| p.as_str());
 
-        let client_ip = request
+        let peer = request
             .extensions()
             .get::<ConnectInfo<SocketAddr>>()
-            .map(|ConnectInfo(ip)| tracing::field::debug(ip));
+            .map(|ConnectInfo(addr)| *addr);
 
         let span_name = http_route.as_ref().map_or_else(
             || http_method.to_string(),
@@ -91,12 +92,10 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
         let span = dyn_span!(
             self.level,
             "request",
-            http.client_ip = Empty,
-            http.host = Empty,
+            client.address = Empty,
             http.request.method = %fields::extract_http_method(request),
             http.route = Empty,
             http.response.status_code = Empty,
-            http.user_agent = Empty,
             network.protocol.name = fields::extract_network_protocol_name(request),
             network.protocol.version = Empty,
             otel.name = span_name,
@@ -104,23 +103,22 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             otel.status_code = Empty,
             otel.status_description = Empty,
             request_id = Empty,
+            server.address = Empty,
             trace_id = Empty,
             url.path = fields::extract_url_path(request),
             url.query = Empty,
-            url.scheme = Empty
+            url.scheme = Empty,
+            user_agent.original = Empty
         );
 
-        if let Some(client_ip) = client_ip {
-            span.record("http.client_ip", client_ip);
-        }
         if let Some(host) = fields::extract_host(request) {
-            span.record("http.host", host);
+            span.record("server.address", host);
         }
         if let Some(route) = http_route {
             span.record("http.route", route);
         }
         if let Some(user_agent) = fields::extract_user_agent(request) {
-            span.record("http.user_agent", user_agent);
+            span.record("user_agent.original", user_agent);
         }
         if let Some(version) = fields::extract_network_protocol_version(request) {
             span.record("network.protocol.version", version);
@@ -133,6 +131,9 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
         }
         if let Some(scheme) = fields::extract_url_scheme(request) {
             span.record("url.scheme", scheme);
+        }
+        if let Some(peer) = peer {
+            span.record("client.address", peer.ip().to_string());
         }
 
         context::set_otel_parent(request.headers(), &span);

--- a/crates/axum-otel/src/on_failure.rs
+++ b/crates/axum-otel/src/on_failure.rs
@@ -6,7 +6,8 @@ use tracing_otel_extra::dyn_event;
 ///
 /// Original implementation from [tower-http](https://github.com/tower-rs/tower-http/blob/main/tower-http/src/trace/on_failure.rs).
 ///
-/// This component updates the span's `otel.status_code` to "ERROR" when a server error occurs.
+/// This component updates the span's `otel.status_code` and `otel.status_description`
+/// when a server error occurs.
 ///
 /// # Example
 ///
@@ -63,6 +64,10 @@ impl OnFailure<ServerErrorsFailureClass> for AxumOtelOnFailure {
         match failure_classification {
             ServerErrorsFailureClass::StatusCode(status) if status.is_server_error() => {
                 span.record("otel.status_code", "ERROR");
+                span.record(
+                    "otel.status_description",
+                    tracing::field::display(failure_classification),
+                );
             }
             _ => {}
         }

--- a/crates/axum-otel/src/on_response.rs
+++ b/crates/axum-otel/src/on_response.rs
@@ -65,7 +65,7 @@ impl<B> OnResponse<B> for AxumOtelOnResponse {
         span: &tracing::Span,
     ) {
         let status = response.status().as_u16();
-        span.record("http.response.status_code", tracing::field::display(status));
+        span.record("http.response.status_code", i64::from(status));
         span.record("otel.status_code", "OK");
 
         dyn_event!(

--- a/crates/axum-otel/src/on_response.rs
+++ b/crates/axum-otel/src/on_response.rs
@@ -9,7 +9,7 @@ use tracing_otel_extra::dyn_event;
 ///
 /// This component adds the following attributes to the span:
 ///
-/// - `http.status_code`: The response status code
+/// - `http.response.status_code`: The response status code
 /// - `otel.status_code`: The OpenTelemetry status code (OK for successful responses)
 ///
 /// # Example
@@ -65,7 +65,7 @@ impl<B> OnResponse<B> for AxumOtelOnResponse {
         span: &tracing::Span,
     ) {
         let status = response.status().as_u16();
-        span.record("http.status_code", tracing::field::display(status));
+        span.record("http.response.status_code", tracing::field::display(status));
         span.record("otel.status_code", "OK");
 
         dyn_event!(

--- a/crates/axum-otel/tests/integration.rs
+++ b/crates/axum-otel/tests/integration.rs
@@ -31,12 +31,11 @@ fn span_attr(span: &opentelemetry_sdk::trace::SpanData, key: &str) -> Option<Str
     span.attributes
         .iter()
         .find(|kv| kv.key.as_str() == key)
-        .map(|kv| kv.value.to_string())
-        .map(|value| {
-            value
-                .strip_prefix('"')
-                .and_then(|value| value.strip_suffix('"'))
-                .unwrap_or(&value)
+        .map(|kv| {
+            let s = kv.value.to_string();
+            s.strip_prefix('"')
+                .and_then(|unquoted| unquoted.strip_suffix('"'))
+                .unwrap_or(&s)
                 .to_string()
         })
 }

--- a/crates/axum-otel/tests/integration.rs
+++ b/crates/axum-otel/tests/integration.rs
@@ -129,9 +129,9 @@ async fn test_axum_otel_middleware() {
     );
 
     assert_eq!(
-        span_attr(request_span, "http.host"),
+        span_attr(request_span, "server.address"),
         Some("example.com".to_string()),
-        "Expected http.host to be example.com"
+        "Expected server.address to be example.com"
     );
     assert_eq!(
         span_attr(request_span, "http.request.method"),
@@ -139,9 +139,9 @@ async fn test_axum_otel_middleware() {
         "Expected http.request.method to be GET"
     );
     assert_eq!(
-        span_attr(request_span, "http.user_agent"),
+        span_attr(request_span, "user_agent.original"),
         Some("integration-test".to_string()),
-        "Expected http.user_agent to be integration-test"
+        "Expected user_agent.original to be integration-test"
     );
     assert_eq!(
         span_attr(request_span, "http.response.status_code"),
@@ -187,6 +187,16 @@ async fn test_axum_otel_middleware() {
         span_attr(request_span, "http.target"),
         None,
         "Expected deprecated http.target to be absent"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.host"),
+        None,
+        "Expected deprecated http.host to be absent"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.user_agent"),
+        None,
+        "Expected deprecated http.user_agent to be absent"
     );
 
     provider
@@ -246,14 +256,14 @@ async fn test_axum_otel_omits_missing_optional_fields() {
         .expect("Request span not found");
 
     assert_eq!(
-        span_attr(request_span, "http.host"),
+        span_attr(request_span, "server.address"),
         None,
-        "Expected http.host to be omitted when missing"
+        "Expected server.address to be omitted when missing"
     );
     assert_eq!(
-        span_attr(request_span, "http.user_agent"),
+        span_attr(request_span, "user_agent.original"),
         None,
-        "Expected http.user_agent to be omitted when missing"
+        "Expected user_agent.original to be omitted when missing"
     );
     assert_eq!(
         span_attr(request_span, "url.query"),

--- a/crates/axum-otel/tests/integration.rs
+++ b/crates/axum-otel/tests/integration.rs
@@ -11,14 +11,34 @@ use opentelemetry_sdk::{
     Resource,
     trace::{InMemorySpanExporter, RandomIdGenerator, Sampler, SdkTracerProvider},
 };
+use std::sync::{Mutex, OnceLock};
 use tower::ServiceExt;
 use tower_http::trace::TraceLayer;
 use tracing::instrument;
-use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{Registry, layer::SubscriberExt};
+
+fn test_lock() -> &'static Mutex<()> {
+    static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    TEST_LOCK.get_or_init(|| Mutex::new(()))
+}
 
 #[instrument]
 async fn hello() -> &'static str {
     "Hello, world!"
+}
+
+fn span_attr(span: &opentelemetry_sdk::trace::SpanData, key: &str) -> Option<String> {
+    span.attributes
+        .iter()
+        .find(|kv| kv.key.as_str() == key)
+        .map(|kv| kv.value.to_string())
+        .map(|value| {
+            value
+                .strip_prefix('"')
+                .and_then(|value| value.strip_suffix('"'))
+                .unwrap_or(&value)
+                .to_string()
+        })
 }
 
 fn app() -> Router<()> {
@@ -30,8 +50,10 @@ fn app() -> Router<()> {
     )
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn test_axum_otel_middleware() {
+    let _test_guard = test_lock().lock().expect("test lock poisoned");
+
     // Set up in-memory exporter for testing
     let exporter = InMemorySpanExporter::default();
     let provider: SdkTracerProvider = SdkTracerProvider::builder()
@@ -46,10 +68,8 @@ async fn test_axum_otel_middleware() {
     // Set up tracing subscriber with OpenTelemetry layer
     let tracer = provider.tracer("axum-otel-test".to_string());
     let otel_layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
-    Registry::default()
-        .with(otel_layer)
-        .try_init()
-        .expect("Failed to initialize tracing subscriber");
+    let subscriber = Registry::default().with(otel_layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
 
     let app = app();
 
@@ -57,7 +77,10 @@ async fn test_axum_otel_middleware() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/")
+                .uri("/?foo=bar")
+                .header("host", "example.com")
+                .header("user-agent", "integration-test")
+                .header("x-forwarded-proto", "https")
                 .method(Method::GET)
                 .body(Body::empty())
                 .expect("Failed to build request"),
@@ -106,17 +129,142 @@ async fn test_axum_otel_middleware() {
         "Handler span should be a child of the request span"
     );
 
-    // Check http.status_code attribute
-    let status_code_attr = request_span
-        .attributes
+    assert_eq!(
+        span_attr(request_span, "http.host"),
+        Some("example.com".to_string()),
+        "Expected http.host to be example.com"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.request.method"),
+        Some("GET".to_string()),
+        "Expected http.request.method to be GET"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.user_agent"),
+        Some("integration-test".to_string()),
+        "Expected http.user_agent to be integration-test"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.response.status_code"),
+        Some("200".to_string()),
+        "Expected http.response.status_code to be 200"
+    );
+    assert_eq!(
+        span_attr(request_span, "url.path"),
+        Some("/".to_string()),
+        "Expected url.path to be /"
+    );
+    assert_eq!(
+        span_attr(request_span, "url.scheme"),
+        Some("https".to_string()),
+        "Expected url.scheme to be https"
+    );
+    assert_eq!(
+        span_attr(request_span, "url.query"),
+        Some("foo=bar".to_string()),
+        "Expected url.query to be foo=bar"
+    );
+    assert_eq!(
+        span_attr(request_span, "network.protocol.name"),
+        Some("http".to_string()),
+        "Expected network.protocol.name to be http"
+    );
+    assert_eq!(
+        span_attr(request_span, "network.protocol.version"),
+        Some("1.1".to_string()),
+        "Expected network.protocol.version to be 1.1"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.method"),
+        None,
+        "Expected deprecated http.method to be absent"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.status_code"),
+        None,
+        "Expected deprecated http.status_code to be absent"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.target"),
+        None,
+        "Expected deprecated http.target to be absent"
+    );
+
+    provider
+        .shutdown()
+        .expect("Failed to shutdown tracer provider");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_axum_otel_omits_missing_optional_fields() {
+    let _test_guard = test_lock().lock().expect("test lock poisoned");
+
+    let exporter = InMemorySpanExporter::default();
+    let provider: SdkTracerProvider = SdkTracerProvider::builder()
+        .with_sampler(Sampler::AlwaysOn)
+        .with_id_generator(RandomIdGenerator::default())
+        .with_simple_exporter(exporter.clone())
+        .with_resource(Resource::builder().build())
+        .build();
+
+    global::set_tracer_provider(provider.clone());
+
+    let tracer = provider.tracer("axum-otel-test-optional".to_string());
+    let otel_layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
+    let subscriber = Registry::default().with(otel_layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let app = app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .method(Method::GET)
+                .body(Body::empty())
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let _body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Failed to read body");
+
+    let _ = provider.force_flush();
+
+    let spans = exporter
+        .get_finished_spans()
+        .expect("Failed to get finished spans");
+
+    let request_span = spans
         .iter()
-        .find(|kv| kv.key.as_str() == "http.status_code")
-        .map(|kv| kv.value.to_string());
+        .find(|s| s.name == "GET" || s.name == "GET /")
+        .expect("Request span not found");
 
     assert_eq!(
-        status_code_attr,
-        Some("200".to_string()),
-        "Expected http.status_code to be 200"
+        span_attr(request_span, "http.host"),
+        None,
+        "Expected http.host to be omitted when missing"
+    );
+    assert_eq!(
+        span_attr(request_span, "http.user_agent"),
+        None,
+        "Expected http.user_agent to be omitted when missing"
+    );
+    assert_eq!(
+        span_attr(request_span, "url.query"),
+        None,
+        "Expected url.query to be omitted when missing"
+    );
+    assert_eq!(
+        span_attr(request_span, "url.scheme"),
+        None,
+        "Expected url.scheme to be omitted when missing"
     );
 
     provider

--- a/crates/tracing-otel/CHANGELOG.md
+++ b/crates/tracing-otel/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- [`make_request_span`](https://docs.rs/tracing-otel-extra/latest/tracing_otel_extra/http/span/fn.make_request_span.html) emits the same OpenTelemetry-aligned HTTP attribute names as `axum-otel` (for example `server.address` and `user_agent.original` instead of `http.host` and `http.user_agent`). Update any code or tests that depend on the previous field names.
+
+### 📚 Documentation
+
+- Document HTTP span attributes in `http::span` and link to the OpenTelemetry HTTP spec and `axum-otel` migration notes; README mentions `make_request_span`.
+
 ### 🐛 Bug Fixes
 
 - Change default environment variable prefix from `LOG_` to `LOG` to avoid double underscores in variable names (e.g., `LOG__SERVICE_NAME` → `LOG_SERVICE_NAME`)

--- a/crates/tracing-otel/README.md
+++ b/crates/tracing-otel/README.md
@@ -15,6 +15,7 @@ A tracing and OpenTelemetry integration utility library for Rust applications, p
 - **Built-in Metrics Support** - Integrated OpenTelemetry metrics collection and export
 - **Environment Detection** - Automatic detection of operating system and process information
 - **OTLP Export** - Built-in OTLP protocol support, can directly export to Jaeger, OTEL Collector, etc.
+- **HTTP request spans** (with `http` + `span` features) - [`make_request_span`](https://docs.rs/tracing-otel-extra/latest/tracing_otel_extra/http/span/fn.make_request_span.html) uses OpenTelemetry-aligned attribute names; see the [`http::span`](https://docs.rs/tracing-otel-extra/latest/tracing_otel_extra/http/span/index.html) module and [`axum-otel`](https://docs.rs/axum-otel) for migration notes.
 
 ## Quick Start
 

--- a/crates/tracing-otel/src/http/fields.rs
+++ b/crates/tracing-otel/src/http/fields.rs
@@ -4,6 +4,8 @@ use http::{HeaderName, Request};
 
 pub const X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
 pub const REQUEST_ID: HeaderName = HeaderName::from_static("request-id");
+pub const X_FORWARDED_PROTO: HeaderName = HeaderName::from_static("x-forwarded-proto");
+pub const FORWARDED: HeaderName = HeaderName::from_static("forwarded");
 
 /// Extract the http method from the request
 pub fn extract_http_method<T>(request: &Request<T>) -> &str {
@@ -20,14 +22,54 @@ pub fn extract_http_version<T>(request: &http::Request<T>) -> http::Version {
     request.version()
 }
 
+/// Returns the OpenTelemetry [`network.protocol.name`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/network/).
+///
+/// The registry describes this as the **application-layer** protocol (examples include `http`, not
+/// `https`). Use [`extract_http_scheme`] for [`url.scheme`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/)
+/// (`http` vs `https`), and [`extract_network_protocol_version`] for
+/// [`network.protocol.version`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/)
+/// (e.g. `1.1`, `2`).
+pub fn extract_network_protocol_name<T>(_request: &http::Request<T>) -> &'static str {
+    "http"
+}
+
+/// Extract the network protocol version from the request.
+pub fn extract_network_protocol_version<T>(request: &http::Request<T>) -> Option<&'static str> {
+    match request.version() {
+        http::Version::HTTP_09 => Some("0.9"),
+        http::Version::HTTP_10 => Some("1.0"),
+        http::Version::HTTP_11 => Some("1.1"),
+        http::Version::HTTP_2 => Some("2"),
+        http::Version::HTTP_3 => Some("3"),
+        _ => None,
+    }
+}
+
 /// Extract the http scheme from the request
 pub fn extract_http_scheme<T>(request: &http::Request<T>) -> Option<&str> {
     request.uri().scheme().map(|s| s.as_str())
 }
 
+/// Extract the URL scheme from the request URI or proxy headers.
+pub fn extract_url_scheme<T>(request: &http::Request<T>) -> Option<&str> {
+    extract_http_scheme(request)
+        .or_else(|| extract_field_from_headers(request.headers(), &X_FORWARDED_PROTO))
+        .or_else(|| extract_forwarded_proto(request.headers()))
+}
+
 /// Extract the http target from the request
 pub fn extract_http_target<T>(request: &http::Request<T>) -> Option<&str> {
     request.uri().path_and_query().map(|s| s.as_str())
+}
+
+/// Extract the URL path from the request.
+pub fn extract_url_path<T>(request: &http::Request<T>) -> &str {
+    request.uri().path()
+}
+
+/// Extract the URL query from the request.
+pub fn extract_url_query<T>(request: &http::Request<T>) -> Option<&str> {
+    request.uri().query()
 }
 
 /// Extract the user agent from the request headers
@@ -41,8 +83,8 @@ pub fn extract_host<T>(request: &http::Request<T>) -> Option<&str> {
 }
 
 /// Extract the request id from the request headers
-pub fn extract_request_id<T>(request: &http::Request<T>) -> &str {
-    extract_request_id_from_headers(request.headers()).unwrap_or_default()
+pub fn extract_request_id<T>(request: &http::Request<T>) -> Option<&str> {
+    extract_request_id_from_headers(request.headers())
 }
 
 /// Extract the request id from the request headers
@@ -59,6 +101,21 @@ pub fn extract_field_from_headers<'a>(
     field: &HeaderName,
 ) -> Option<&'a str> {
     headers.get(field).and_then(|value| value.to_str().ok())
+}
+
+fn extract_forwarded_proto(headers: &http::HeaderMap) -> Option<&str> {
+    let forwarded = extract_field_from_headers(headers, &FORWARDED)?;
+
+    forwarded.split(',').find_map(|entry| {
+        entry.split(';').find_map(|part| {
+            let (key, value) = part.trim().split_once('=')?;
+            if key.eq_ignore_ascii_case("proto") {
+                Some(value.trim_matches('"'))
+            } else {
+                None
+            }
+        })
+    })
 }
 
 #[cfg(test)]
@@ -78,7 +135,7 @@ mod tests {
     fn test_extract_request_id_without_request_id() {
         let request = Request::builder().body(()).unwrap();
         let request_id = extract_request_id(&request);
-        assert_eq!(request_id, "");
+        assert_eq!(request_id, None);
     }
 
     #[test]
@@ -99,5 +156,67 @@ mod tests {
             .unwrap();
         let host = extract_host(&request);
         assert_eq!(host, Some("test-host"));
+    }
+
+    #[test]
+    fn test_extract_network_protocol_name() {
+        let request = Request::builder().body(()).unwrap();
+        assert_eq!(extract_network_protocol_name(&request), "http");
+    }
+
+    /// Per OTel registry, application protocol name stays `http` even for `https://` URIs.
+    #[test]
+    fn test_extract_network_protocol_name_https_uri_still_http() {
+        let request = Request::builder()
+            .uri("https://example.com/path")
+            .body(())
+            .unwrap();
+        assert_eq!(extract_network_protocol_name(&request), "http");
+        assert_eq!(extract_url_scheme(&request), Some("https"));
+    }
+
+    #[test]
+    fn test_extract_network_protocol_version() {
+        let request = Request::builder()
+            .version(http::Version::HTTP_2)
+            .body(())
+            .unwrap();
+        let version = extract_network_protocol_version(&request);
+        assert_eq!(version, Some("2"));
+    }
+
+    #[test]
+    fn test_extract_url_parts() {
+        let request = Request::builder().uri("/items?kind=test").body(()).unwrap();
+        let path = extract_url_path(&request);
+        let query = extract_url_query(&request);
+        assert_eq!(path, "/items");
+        assert_eq!(query, Some("kind=test"));
+    }
+
+    #[test]
+    fn test_extract_url_scheme_from_x_forwarded_proto() {
+        let request = Request::builder()
+            .uri("/items")
+            .header(X_FORWARDED_PROTO, "https")
+            .body(())
+            .unwrap();
+        assert_eq!(extract_url_scheme(&request), Some("https"));
+    }
+
+    #[test]
+    fn test_extract_url_scheme_from_forwarded_header() {
+        let request = Request::builder()
+            .uri("/items")
+            .header(FORWARDED, "for=192.0.2.60;proto=https;by=203.0.113.43")
+            .body(())
+            .unwrap();
+        assert_eq!(extract_url_scheme(&request), Some("https"));
+    }
+
+    #[test]
+    fn test_extract_request_id_absent() {
+        let request = Request::builder().body(()).unwrap();
+        assert_eq!(extract_request_id(&request), None);
     }
 }

--- a/crates/tracing-otel/src/http/fields.rs
+++ b/crates/tracing-otel/src/http/fields.rs
@@ -77,7 +77,7 @@ pub fn extract_user_agent<T>(request: &http::Request<T>) -> Option<&str> {
     extract_field_from_headers(request.headers(), &http::header::USER_AGENT)
 }
 
-/// Extract the client ip from the request headers
+/// Extract the `Host` header value.
 pub fn extract_host<T>(request: &http::Request<T>) -> Option<&str> {
     extract_field_from_headers(request.headers(), &http::header::HOST)
 }
@@ -212,11 +212,5 @@ mod tests {
             .body(())
             .unwrap();
         assert_eq!(extract_url_scheme(&request), Some("https"));
-    }
-
-    #[test]
-    fn test_extract_request_id_absent() {
-        let request = Request::builder().body(()).unwrap();
-        assert_eq!(extract_request_id(&request), None);
     }
 }

--- a/crates/tracing-otel/src/http/span.rs
+++ b/crates/tracing-otel/src/http/span.rs
@@ -13,11 +13,9 @@ pub fn make_request_span<B>(level: Level, request: &Request<B>) -> Span {
         level,
         "request",
         // HTTP fields
-        http.host = Empty,
         http.request.method = %fields::extract_http_method(request),
         http.route = Empty,
         http.response.status_code = Empty,
-        http.user_agent = Empty,
         network.protocol.name = fields::extract_network_protocol_name(request),
         network.protocol.version = Empty,
         // OpenTelemetry fields
@@ -27,17 +25,19 @@ pub fn make_request_span<B>(level: Level, request: &Request<B>) -> Span {
         otel.status_description = Empty,
         // Request tracking
         request_id = Empty,
+        server.address = Empty,
         trace_id = Empty,
         url.path = fields::extract_url_path(request),
         url.query = Empty,
-        url.scheme = Empty
+        url.scheme = Empty,
+        user_agent.original = Empty
     );
 
     if let Some(host) = fields::extract_host(request) {
-        span.record("http.host", host);
+        span.record("server.address", host);
     }
     if let Some(user_agent) = fields::extract_user_agent(request) {
-        span.record("http.user_agent", user_agent);
+        span.record("user_agent.original", user_agent);
     }
     if let Some(version) = fields::extract_network_protocol_version(request) {
         span.record("network.protocol.version", version);

--- a/crates/tracing-otel/src/http/span.rs
+++ b/crates/tracing-otel/src/http/span.rs
@@ -13,22 +13,45 @@ pub fn make_request_span<B>(level: Level, request: &Request<B>) -> Span {
         level,
         "request",
         // HTTP fields
-        http.version = ?fields::extract_http_version(request),
-        http.host = ?fields::extract_host(request),
-        http.method = ?fields::extract_http_method(request),
+        http.host = Empty,
+        http.request.method = %fields::extract_http_method(request),
         http.route = Empty,
-        http.scheme = ?fields::extract_http_scheme(request).map(debug),
-        http.status = Empty,
-        http.target = ?fields::extract_http_target(request),
-        http.user_agent = ?fields::extract_user_agent(request),
+        http.response.status_code = Empty,
+        http.user_agent = Empty,
+        network.protocol.name = fields::extract_network_protocol_name(request),
+        network.protocol.version = Empty,
         // OpenTelemetry fields
         otel.name = Empty,
         otel.kind = ?Empty,
-        otel.status = Empty,
+        otel.status_code = Empty,
+        otel.status_description = Empty,
         // Request tracking
-        request_id = %fields::extract_request_id(request),
-        trace_id = Empty
+        request_id = Empty,
+        trace_id = Empty,
+        url.path = fields::extract_url_path(request),
+        url.query = Empty,
+        url.scheme = Empty
     );
+
+    if let Some(host) = fields::extract_host(request) {
+        span.record("http.host", host);
+    }
+    if let Some(user_agent) = fields::extract_user_agent(request) {
+        span.record("http.user_agent", user_agent);
+    }
+    if let Some(version) = fields::extract_network_protocol_version(request) {
+        span.record("network.protocol.version", version);
+    }
+    if let Some(request_id) = fields::extract_request_id(request) {
+        span.record("request_id", request_id);
+    }
+    if let Some(query) = fields::extract_url_query(request) {
+        span.record("url.query", query);
+    }
+    if let Some(scheme) = fields::extract_url_scheme(request) {
+        span.record("url.scheme", scheme);
+    }
+
     context::set_otel_parent(request.headers(), &span);
     span
 }

--- a/crates/tracing-otel/src/http/span.rs
+++ b/crates/tracing-otel/src/http/span.rs
@@ -1,4 +1,8 @@
 //! HTTP request span creation utilities.
+//!
+//! [`make_request_span`] sets attributes that match [OpenTelemetry HTTP server spans](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)
+//! (for example `server.address`, `user_agent.original`, `url.path`, `url.scheme`, `network.protocol.*`).
+//! See the [`axum_otel` crate](https://docs.rs/axum-otel) documentation for a migration table from older attribute names.
 
 use crate::{
     dyn_span,


### PR DESCRIPTION
## Background
- The HTTP tracing layer was still emitting deprecated OpenTelemetry HTTP span attributes.
- Issue #1 updates the library to the current semantic convention keys and stops writing the legacy ones.

## Changes
- Update `axum-otel` request spans to emit current HTTP, URL, and network attributes such as `http.request.method`, `http.response.status_code`, `url.path`, `url.query`, `url.scheme`, and `network.protocol.*`.
- Update response and failure handlers to record the new response status field and populate `otel.status_description` on server errors.
- Add shared field extractors in `tracing-otel-extra` for URL parts and network protocol metadata, and update the generic HTTP span builder to use the same naming scheme.
- Expand the integration test to assert the new attributes and verify deprecated keys like `http.method`, `http.status_code`, and `http.target` are no longer emitted.

## Impact
- Telemetry consumers need to read the new semantic convention keys after upgrading.
- Span data is now consistent across `axum-otel` and the shared HTTP span utilities.

## Validation
- `cargo test -p axum-otel test_axum_otel_middleware -- --nocapture`
- `cargo test -p tracing-otel-extra --features "fields,http,span,macros" --lib -- --nocapture`