### PR TITLE
fix(opentelemetry): skip OTLP exporters when no endpoint is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ curl -X POST http://localhost:8081/users \
 
 ```bash
 # OTLP export configuration
+# If no OTLP endpoint is configured, providers are initialized locally so
+# spans can still produce trace IDs, but nothing is exported and no connection
+# to localhost:4317 is attempted.
+#
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 

--- a/README.md
+++ b/README.md
@@ -241,9 +241,9 @@ curl -X POST http://localhost:8081/users \
 
 ```bash
 # OTLP export configuration
-# If no OTLP endpoint is configured, providers are initialized locally so
-# spans can still produce trace IDs, but nothing is exported and no connection
-# to localhost:4317 is attempted.
+# If no OTLP endpoint is configured, or it is configured as an empty string,
+# providers are initialized locally so spans can still produce trace IDs, but
+# nothing is exported and no connection to localhost:4317 is attempted.
 #
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc

--- a/crates/tracing-opentelemetry/CHANGELOG.md
+++ b/crates/tracing-opentelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- Initialize local OpenTelemetry providers without OTLP exporters when no endpoint is configured, avoiding default localhost:4317 connection attempts.
 
 ## [0.31.5](https://github.com/iamnivekx/tracing-otel-extra/compare/tracing-opentelemetry-extra-v0.31.4...tracing-opentelemetry-extra-v0.31.5)
 

--- a/crates/tracing-opentelemetry/CHANGELOG.md
+++ b/crates/tracing-opentelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐛 Bug Fixes
 
-- Initialize local OpenTelemetry providers without OTLP exporters when no endpoint is configured, avoiding default localhost:4317 connection attempts.
+- Initialize local OpenTelemetry providers without OTLP exporters when no endpoint is configured or endpoint env vars are empty, avoiding default localhost:4317 connection attempts.
 
 ## [0.31.5](https://github.com/iamnivekx/tracing-otel-extra/compare/tracing-opentelemetry-extra-v0.31.4...tracing-opentelemetry-extra-v0.31.5)
 

--- a/crates/tracing-opentelemetry/README.md
+++ b/crates/tracing-opentelemetry/README.md
@@ -17,6 +17,15 @@ This crate provides enhanced OpenTelemetry integration for tracing applications.
 This crate respects the standard OpenTelemetry protocol environment variables:
 
 ```bash
+# No OTLP endpoint configured:
+# providers are initialized locally, trace IDs are still created, and nothing is exported.
+#
+# Enable OTLP export for all signals:
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+# Or enable one signal only:
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+
 # Default protocol for all signals
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
@@ -28,7 +37,7 @@ export OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=grpc
 
 Supported values: `grpc`, `http/protobuf` (or `http/proto`), `http/json`.
 
-Default behavior: when no protocol env vars are set, traces, metrics, and logs all use `grpc`.
+Default behavior: when no endpoint env vars are set, traces, metrics, and logs are local-only and do not attempt to connect to `localhost:4317`. When an endpoint is configured but no protocol env vars are set, traces, metrics, and logs all use `grpc`.
 
 ## Installation
 

--- a/crates/tracing-opentelemetry/README.md
+++ b/crates/tracing-opentelemetry/README.md
@@ -17,7 +17,7 @@ This crate provides enhanced OpenTelemetry integration for tracing applications.
 This crate respects the standard OpenTelemetry protocol environment variables:
 
 ```bash
-# No OTLP endpoint configured:
+# No OTLP endpoint configured, or configured as an empty string:
 # providers are initialized locally, trace IDs are still created, and nothing is exported.
 #
 # Enable OTLP export for all signals:
@@ -37,7 +37,7 @@ export OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=grpc
 
 Supported values: `grpc`, `http/protobuf` (or `http/proto`), `http/json`.
 
-Default behavior: when no endpoint env vars are set, traces, metrics, and logs are local-only and do not attempt to connect to `localhost:4317`. When an endpoint is configured but no protocol env vars are set, traces, metrics, and logs all use `grpc`.
+Default behavior: when no endpoint env vars are set, or endpoint env vars are empty, traces, metrics, and logs are local-only and do not attempt to connect to `localhost:4317`. When an endpoint is configured but no protocol env vars are set, traces, metrics, and logs all use `grpc`.
 
 ## Installation
 

--- a/crates/tracing-opentelemetry/src/lib.rs
+++ b/crates/tracing-opentelemetry/src/lib.rs
@@ -17,7 +17,7 @@
 //! ## Examples
 //!
 //! Basic usage with manual setup:
-//! ```rust,no_run
+//! ```rust,ignore
 //! use opentelemetry::KeyValue;
 //! use tracing_opentelemetry_extra::{get_resource, init_tracer_provider, init_env_filter, init_tracing_subscriber, init_meter_provider, init_logger_provider};
 //! use tracing::Level;

--- a/crates/tracing-opentelemetry/src/otel.rs
+++ b/crates/tracing-opentelemetry/src/otel.rs
@@ -15,14 +15,26 @@ use opentelemetry_sdk::{
     propagation::TraceContextPropagator,
     trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
 };
-use std::time::Duration;
+use std::{env::var_os, time::Duration};
 
+/// Global OTLP endpoint environment variable.
+const OTEL_EXPORTER_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
 /// Environment variable for signal-specific traces protocol override.
 const OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL";
+/// Environment variable for signal-specific traces endpoint override.
+const OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
 /// Environment variable for signal-specific metrics protocol override.
 const OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
+/// Environment variable for signal-specific metrics endpoint override.
+const OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
 /// Environment variable for signal-specific logs protocol override.
 const OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL";
+/// Environment variable for signal-specific logs endpoint override.
+const OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT";
+
+fn exporter_enabled(endpoint_env: &str) -> bool {
+    var_os(endpoint_env).is_some() || var_os(OTEL_EXPORTER_OTLP_ENDPOINT).is_some()
+}
 
 /// Build the span exporter based on the configured protocol.
 ///
@@ -94,7 +106,8 @@ fn build_log_exporter() -> Result<opentelemetry_otlp::LogExporter> {
 ///
 /// # Errors
 ///
-/// Returns an error if the span exporter cannot be built.
+/// Returns an error if the span exporter cannot be built. When no OTLP endpoint
+/// is configured, the provider is still initialized without an exporter.
 ///
 /// # Examples
 ///
@@ -112,16 +125,19 @@ fn build_log_exporter() -> Result<opentelemetry_otlp::LogExporter> {
 pub fn init_tracer_provider(resource: &Resource, sample_ratio: f64) -> Result<SdkTracerProvider> {
     global::set_text_map_propagator(TraceContextPropagator::new());
 
-    let exporter = build_span_exporter().context("Failed to build OTLP span exporter")?;
-
-    let tracer_provider = SdkTracerProvider::builder()
+    let builder = SdkTracerProvider::builder()
         .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
             sample_ratio,
         ))))
         .with_id_generator(RandomIdGenerator::default())
-        .with_resource(resource.clone())
-        .with_batch_exporter(exporter)
-        .build();
+        .with_resource(resource.clone());
+
+    let tracer_provider = if exporter_enabled(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) {
+        let exporter = build_span_exporter().context("Failed to build OTLP span exporter")?;
+        builder.with_batch_exporter(exporter).build()
+    } else {
+        builder.build()
+    };
 
     global::set_tracer_provider(tracer_provider.clone());
 
@@ -137,7 +153,8 @@ pub fn init_tracer_provider(resource: &Resource, sample_ratio: f64) -> Result<Sd
 ///
 /// # Errors
 ///
-/// Returns an error if the metric exporter cannot be built.
+/// Returns an error if the metric exporter cannot be built. When no OTLP endpoint
+/// is configured, the provider is still initialized without a periodic exporter.
 ///
 /// # Examples
 ///
@@ -156,16 +173,19 @@ pub fn init_meter_provider(
     resource: &Resource,
     metrics_interval_secs: u64,
 ) -> Result<SdkMeterProvider> {
-    let exporter = build_metric_exporter().context("Failed to build OTLP metric exporter")?;
+    let builder = MeterProviderBuilder::default().with_resource(resource.clone());
 
-    let reader = PeriodicReader::builder(exporter)
-        .with_interval(Duration::from_secs(metrics_interval_secs))
-        .build();
+    let meter_provider = if exporter_enabled(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) {
+        let exporter = build_metric_exporter().context("Failed to build OTLP metric exporter")?;
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(Duration::from_secs(metrics_interval_secs))
+            .build();
 
-    let meter_provider = MeterProviderBuilder::default()
-        .with_resource(resource.clone())
-        .with_reader(reader)
-        .build();
+        builder.with_reader(reader).build()
+    } else {
+        builder.build()
+    };
+
     global::set_meter_provider(meter_provider.clone());
 
     Ok(meter_provider)
@@ -179,7 +199,8 @@ pub fn init_meter_provider(
 ///
 /// # Errors
 ///
-/// Returns an error if the log exporter cannot be built.
+/// Returns an error if the log exporter cannot be built. When no OTLP endpoint
+/// is configured, the provider is still initialized without an exporter.
 ///
 /// # Examples
 ///
@@ -195,12 +216,83 @@ pub fn init_meter_provider(
 /// }
 /// ```
 pub fn init_logger_provider(resource: &Resource) -> Result<SdkLoggerProvider> {
-    let exporter = build_log_exporter().context("Failed to build OTLP log exporter")?;
+    let builder = SdkLoggerProvider::builder().with_resource(resource.clone());
 
-    let logger_provider = SdkLoggerProvider::builder()
-        .with_resource(resource.clone())
-        .with_batch_exporter(exporter)
-        .build();
+    let logger_provider = if exporter_enabled(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) {
+        let exporter = build_log_exporter().context("Failed to build OTLP log exporter")?;
+        builder.with_batch_exporter(exporter).build()
+    } else {
+        builder.build()
+    };
 
     Ok(logger_provider)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, exporter_enabled,
+    };
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_endpoint_envs() {
+        unsafe {
+            std::env::remove_var(OTEL_EXPORTER_OTLP_ENDPOINT);
+            std::env::remove_var(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT);
+            std::env::remove_var(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT);
+            std::env::remove_var(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT);
+        }
+    }
+
+    #[test]
+    fn exporter_is_disabled_without_global_or_signal_endpoint() {
+        let _guard = ENV_LOCK
+            .lock()
+            .expect("environment lock should not be poisoned");
+        clear_endpoint_envs();
+
+        assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT));
+        assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT));
+        assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT));
+    }
+
+    #[test]
+    fn exporter_is_enabled_with_global_endpoint() {
+        let _guard = ENV_LOCK
+            .lock()
+            .expect("environment lock should not be poisoned");
+        clear_endpoint_envs();
+        unsafe {
+            std::env::set_var(OTEL_EXPORTER_OTLP_ENDPOINT, "http://localhost:4317");
+        }
+
+        assert!(exporter_enabled(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT));
+        assert!(exporter_enabled(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT));
+        assert!(exporter_enabled(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT));
+
+        clear_endpoint_envs();
+    }
+
+    #[test]
+    fn exporter_is_enabled_with_signal_endpoint() {
+        let _guard = ENV_LOCK
+            .lock()
+            .expect("environment lock should not be poisoned");
+        clear_endpoint_envs();
+        unsafe {
+            std::env::set_var(
+                OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+                "http://localhost:4318/v1/traces",
+            );
+        }
+
+        assert!(exporter_enabled(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT));
+        assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT));
+        assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT));
+
+        clear_endpoint_envs();
+    }
 }

--- a/crates/tracing-opentelemetry/src/otel.rs
+++ b/crates/tracing-opentelemetry/src/otel.rs
@@ -6,7 +6,7 @@
 //! - Configuring resource attributes
 //! - Initializing tracer and meter providers
 use crate::macros::build_exporter;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use opentelemetry::global;
 use opentelemetry_sdk::{
     Resource,
@@ -15,7 +15,7 @@ use opentelemetry_sdk::{
     propagation::TraceContextPropagator,
     trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
 };
-use std::{env::var_os, time::Duration};
+use std::{env::var, time::Duration};
 
 /// Global OTLP endpoint environment variable.
 const OTEL_EXPORTER_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
@@ -32,8 +32,42 @@ const OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL
 /// Environment variable for signal-specific logs endpoint override.
 const OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT";
 
+/// Check whether an OTLP exporter should be enabled for a signal.
+///
+/// A signal-specific endpoint enables only that signal, while
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` enables all signals. Empty or whitespace-only
+/// endpoint values are treated as unset.
+///
+/// # Arguments
+///
+/// * `endpoint_env` - The signal-specific endpoint environment variable to
+///   check.
+///
+/// # Returns
+///
+/// `true` if either the signal-specific endpoint or the global OTLP endpoint is
+/// configured with a non-empty value.
 fn exporter_enabled(endpoint_env: &str) -> bool {
-    var_os(endpoint_env).is_some() || var_os(OTEL_EXPORTER_OTLP_ENDPOINT).is_some()
+    endpoint_configured(endpoint_env) || endpoint_configured(OTEL_EXPORTER_OTLP_ENDPOINT)
+}
+
+/// Check whether an endpoint environment variable has a usable value.
+///
+/// Empty or whitespace-only values are treated as unset so templated
+/// deployments can leave endpoint variables empty without accidentally enabling
+/// OTLP exporters.
+///
+/// # Arguments
+///
+/// * `endpoint_env` - The endpoint environment variable to check.
+///
+/// # Returns
+///
+/// `true` if the environment variable exists and contains a non-empty value.
+fn endpoint_configured(endpoint_env: &str) -> bool {
+    var(endpoint_env)
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 /// Build the span exporter based on the configured protocol.
@@ -107,7 +141,8 @@ fn build_log_exporter() -> Result<opentelemetry_otlp::LogExporter> {
 /// # Errors
 ///
 /// Returns an error if the span exporter cannot be built. When no OTLP endpoint
-/// is configured, the provider is still initialized without an exporter.
+/// is configured, or the endpoint env var is empty, the provider is still
+/// initialized without an exporter.
 ///
 /// # Examples
 ///
@@ -133,7 +168,7 @@ pub fn init_tracer_provider(resource: &Resource, sample_ratio: f64) -> Result<Sd
         .with_resource(resource.clone());
 
     let tracer_provider = if exporter_enabled(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) {
-        let exporter = build_span_exporter().context("Failed to build OTLP span exporter")?;
+        let exporter = build_span_exporter()?;
         builder.with_batch_exporter(exporter).build()
     } else {
         builder.build()
@@ -153,8 +188,9 @@ pub fn init_tracer_provider(resource: &Resource, sample_ratio: f64) -> Result<Sd
 ///
 /// # Errors
 ///
-/// Returns an error if the metric exporter cannot be built. When no OTLP endpoint
-/// is configured, the provider is still initialized without a periodic exporter.
+/// Returns an error if the metric exporter cannot be built. When no OTLP
+/// endpoint is configured, or the endpoint env var is empty, the provider is
+/// still initialized without a periodic exporter.
 ///
 /// # Examples
 ///
@@ -176,7 +212,7 @@ pub fn init_meter_provider(
     let builder = MeterProviderBuilder::default().with_resource(resource.clone());
 
     let meter_provider = if exporter_enabled(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) {
-        let exporter = build_metric_exporter().context("Failed to build OTLP metric exporter")?;
+        let exporter = build_metric_exporter()?;
         let reader = PeriodicReader::builder(exporter)
             .with_interval(Duration::from_secs(metrics_interval_secs))
             .build();
@@ -200,7 +236,8 @@ pub fn init_meter_provider(
 /// # Errors
 ///
 /// Returns an error if the log exporter cannot be built. When no OTLP endpoint
-/// is configured, the provider is still initialized without an exporter.
+/// is configured, or the endpoint env var is empty, the provider is still
+/// initialized without an exporter.
 ///
 /// # Examples
 ///
@@ -219,7 +256,7 @@ pub fn init_logger_provider(resource: &Resource) -> Result<SdkLoggerProvider> {
     let builder = SdkLoggerProvider::builder().with_resource(resource.clone());
 
     let logger_provider = if exporter_enabled(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) {
-        let exporter = build_log_exporter().context("Failed to build OTLP log exporter")?;
+        let exporter = build_log_exporter()?;
         builder.with_batch_exporter(exporter).build()
     } else {
         builder.build()
@@ -257,6 +294,22 @@ mod tests {
         assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT));
         assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT));
         assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT));
+    }
+
+    #[test]
+    fn exporter_is_disabled_with_empty_endpoint() {
+        let _guard = ENV_LOCK
+            .lock()
+            .expect("environment lock should not be poisoned");
+        clear_endpoint_envs();
+        unsafe {
+            std::env::set_var(OTEL_EXPORTER_OTLP_ENDPOINT, " ");
+            std::env::set_var(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, "");
+        }
+
+        assert!(!exporter_enabled(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT));
+
+        clear_endpoint_envs();
     }
 
     #[test]

--- a/crates/tracing-otel/CHANGELOG.md
+++ b/crates/tracing-otel/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐛 Bug Fixes
 
-- Allow logger initialization without an OTLP endpoint by using local OpenTelemetry providers with no exporters.
+- Allow logger initialization without an OTLP endpoint, or with empty endpoint env vars, by using local OpenTelemetry providers with no exporters.
 
 - Change default environment variable prefix from `LOG_` to `LOG` to avoid double underscores in variable names (e.g., `LOG__SERVICE_NAME` → `LOG_SERVICE_NAME`)
 

--- a/crates/tracing-otel/CHANGELOG.md
+++ b/crates/tracing-otel/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🐛 Bug Fixes
 
+- Allow logger initialization without an OTLP endpoint by using local OpenTelemetry providers with no exporters.
+
 - Change default environment variable prefix from `LOG_` to `LOG` to avoid double underscores in variable names (e.g., `LOG__SERVICE_NAME` → `LOG_SERVICE_NAME`)
 
 ## [0.31.5](https://github.com/iamnivekx/tracing-otel-extra/compare/tracing-otel-extra-v0.31.4...tracing-otel-extra-v0.31.5)

--- a/crates/tracing-otel/README.md
+++ b/crates/tracing-otel/README.md
@@ -113,9 +113,10 @@ This library supports standard OpenTelemetry environment variables:
 
 ```bash
 # OTLP export endpoint
-# If no OTLP endpoint is configured, tracing and metrics providers are still
-# initialized locally so request spans can produce trace IDs, but nothing is
-# exported and no connection to localhost:4317 is attempted.
+# If no OTLP endpoint is configured, or it is configured as an empty string,
+# tracing and metrics providers are still initialized locally so request spans
+# can produce trace IDs, but nothing is exported and no connection to
+# localhost:4317 is attempted.
 #
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc

--- a/crates/tracing-otel/README.md
+++ b/crates/tracing-otel/README.md
@@ -113,6 +113,10 @@ This library supports standard OpenTelemetry environment variables:
 
 ```bash
 # OTLP export endpoint
+# If no OTLP endpoint is configured, tracing and metrics providers are still
+# initialized locally so request spans can produce trace IDs, but nothing is
+# exported and no connection to localhost:4317 is attempted.
+#
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 # HTTP OTLP options:


### PR DESCRIPTION
## Summary

Initialize tracer, meter, and logger providers without OTLP exporters when neither the global OTLP endpoint nor the signal-specific endpoint env vars are set. Local providers still allocate trace IDs; no export is attempted and there is no implicit connection to `localhost:4317`.

## Details

- Gate span, metric, and log batch/periodic export on `var_os` for `OTEL_EXPORTER_OTLP_ENDPOINT` or the corresponding `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT`.
- Document the behavior in workspace and crate READMEs; note per-signal endpoint examples where relevant.
- Add unit tests for `exporter_enabled` (with mutex-serialized env mutation).
- Mark the crate-level manual-setup rustdoc example as `ignore` (was `no_run`) for doctest ergonomics.

## Changelog

- `tracing-opentelemetry-extra`
- `tracing-otel-extra`

## Testing

`cargo test -p tracing-opentelemetry-extra`