### PR TITLE
chore: update release configuration in release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,7 @@
 [workspace]
 features_always_increment_minor = true
+release_always = false
+release_commits = "^release[(:]"
 
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
- Added `release_always` set to false to control release behavior.
- Introduced `release_commits` regex pattern to specify commit messages for releases.