### PR TITLE
feat: upgrade OpenTelemetry dependencies to 0.32

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,11 +237,11 @@ mod tests {
 
 | Crate                          | Purpose                         |
 | ------------------------------ | ------------------------------- |
-| `opentelemetry` (0.31)         | Core OpenTelemetry APIs         |
-| `opentelemetry-otlp` (0.31)    | OTLP exporter                   |
+| `opentelemetry` (0.32)         | Core OpenTelemetry APIs         |
+| `opentelemetry-otlp` (0.32)    | OTLP exporter                   |
 | `tracing` (0.1)                | Rust tracing framework          |
 | `tracing-subscriber` (0.3)     | Subscriber implementations      |
-| `tracing-opentelemetry` (0.32) | Bridge between tracing and OTel |
+| `tracing-opentelemetry` (0.33) | Bridge between tracing and OTel |
 | `axum` (0.8)                   | Web framework                   |
 | `tower-http` (0.6)             | HTTP middleware utilities       |
 | `reqwest` (0.13, examples)     | HTTP client in microservices demo |
@@ -251,9 +251,9 @@ mod tests {
 
 ### Version Compatibility Notes
 
-- Examples use `reqwest-tracing` 0.7 with the `opentelemetry_0_31` feature, aligned with workspace OpenTelemetry 0.31.
-- `opentelemetry-otlp` still depends on `reqwest` 0.12 internally; the workspace may resolve both 0.12 and 0.13 until OTLP upgrades.
-- Always check compatibility when upgrading OpenTelemetry crates as they often have breaking changes
+- Examples use `reqwest-tracing` 0.7 with the `opentelemetry_0_32` feature, aligned with workspace OpenTelemetry 0.32.
+- `opentelemetry-otlp` 0.32 resolves to the same workspace `reqwest` 0.13 line (`reqwest` 0.13.4 in the current lockfile).
+- When upgrading OpenTelemetry, verify `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-http`, `opentelemetry-otlp`, `opentelemetry-appender-tracing`, `tracing-opentelemetry`, and `reqwest-tracing` together.
 
 ## Environment Variables
 
@@ -309,4 +309,3 @@ This project uses `release-plz` for automated releases. See `release-plz.toml` f
 - [Axum Framework](https://github.com/tokio-rs/axum)
 - [Tower HTTP](https://github.com/tower-rs/tower-http)
 - [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "axum",
  "axum-otel",
  "dotenvy",
- "reqwest 0.13.4",
+ "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -618,7 +618,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1007,9 +1006,9 @@ checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1021,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -1033,22 +1032,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1056,19 +1055,19 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "base64",
  "const-hex",
@@ -1076,26 +1075,25 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
- "serde_json",
  "tonic",
  "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand",
  "thiserror",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -1166,6 +1164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1238,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1373,46 +1386,6 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -1420,7 +1393,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1460,7 +1435,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror",
  "tower-service",
 ]
@@ -1477,7 +1452,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http",
  "hyper",
- "reqwest 0.13.4",
+ "reqwest",
  "reqwest-middleware",
  "retry-policies",
  "thiserror",
@@ -1498,7 +1473,7 @@ dependencies = [
  "http",
  "matchit",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
  "reqwest-middleware",
  "tracing",
  "tracing-opentelemetry",
@@ -2104,6 +2079,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,16 +2198,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
- "opentelemetry_sdk",
- "rustversion",
  "smallvec",
- "thiserror",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,17 +45,17 @@ config = { version = "0.14.0", default-features = false }
 dotenvy = { version = "0.15.7" }
 http = { version = "1.3.1" }
 http-body-util = { version = "0.1" }
-opentelemetry = { version = "0.31.0", default-features = false }
-opentelemetry-appender-tracing = { version = "0.31.0" }
-opentelemetry-http = { version = "0.31.0", default-features = false }
-opentelemetry-otlp = { version = "0.31.0", features = [
+opentelemetry = { version = "0.32.0", default-features = false }
+opentelemetry-appender-tracing = { version = "0.32.0" }
+opentelemetry-http = { version = "0.32.0", default-features = false }
+opentelemetry-otlp = { version = "0.32.0", features = [
     "grpc-tonic",
     "http-json",
     "http-proto",
     "tls",
     "reqwest-rustls",
 ] }
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
+opentelemetry_sdk = { version = "0.32.0", default-features = false, features = [
     "trace",
     "logs",
 ] }
@@ -64,7 +64,7 @@ opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
 reqwest = { version = "0.13.1", features = ["json"] }
 reqwest-middleware = "0.5.1"
 reqwest-retry = "0.9.1"
-reqwest-tracing = { version = "0.7.0", features = ["opentelemetry_0_31"] }
+reqwest-tracing = { version = "0.7.1", features = ["opentelemetry_0_32"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -77,5 +77,5 @@ tower-http = { version = "0.6.6", features = ["trace"] }
 
 tracing = { version = "0.1.44" }
 tracing-appender = { version = "0.2.4" }
-tracing-opentelemetry = { version = "0.32.0" }
+tracing-opentelemetry = { version = "0.33.0" }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }


### PR DESCRIPTION
## Background
- Upgrade the OpenTelemetry dependency stack to the current 0.32 line.

## Changes
- Upgrade `opentelemetry`, `opentelemetry-http`, `opentelemetry-otlp`, and `opentelemetry-appender-tracing` to 0.32.
- Upgrade `tracing-opentelemetry` to 0.33.
- Upgrade `reqwest-tracing` to 0.7.1 with `opentelemetry_0_32`.
- Refresh `Cargo.lock` with the minimal required dependency changes.
- Update project documentation for the new compatibility matrix.

## Impact
- No behavior changes were made.
- `cargo tree` confirms `opentelemetry` resolves to 0.32 and `reqwest` resolves to 0.13.4.

## Test plan
- [x] `cargo check --workspace --all-features`
- [x] `cargo test --workspace --all-features`
- [x] `cargo test -p tracing-otel-extra --no-default-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`