### PR TITLE
chore: update release configuration and GitHub workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   # Release unpublished packages.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,8 @@
 [workspace]
 features_always_increment_minor = true
 release_always = false
-release_commits = "^release[(:]"
+pr_labels = ["release"]
+changelog_update = false
 
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
## Background
- Adjust the release workflow so publishing is gated by the release PR instead of commit-message based release triggers.

## Changes
- Remove manual `workflow_dispatch` from the Release-plz workflow.
- Keep `release-plz release` and `release-plz release-pr` running on `main` pushes.
- Remove the `release_commits` gate.
- Disable release-plz changelog generation with `changelog_update = false`.
- Add the `release` label to generated release PRs.

## Impact
- Normal PR merges can update or create a release PR, but will not publish directly because `release_always = false`.
- Changelog entries should be added manually in development PRs.

## Test plan
- [x] Parse `release-plz.toml` with `tomllib`
- [x] Parse `.github/workflows/release-plz.yml` as YAML