### PR TITLE
refactor: delegate HTTP server spans to tracing-otel-extra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,9 +226,9 @@ mod tests {
 
 #### Modifying span attributes
 
-1. Update `AxumOtelSpanCreator::make_span` in `crates/axum-otel/src/make_span.rs`
+1. Update the shared HTTP server span schema in `crates/tracing-otel/src/http/span.rs`; framework adapters customize spans through the `make_request_span` callback
 2. Ensure compliance with [OpenTelemetry HTTP traces](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) (see `axum_otel` crate docs on docs.rs for the attribute migration table and `CHANGELOG.md` for breaking renames)
-3. Keep `tracing-otel-extra` `make_request_span` (`crates/tracing-otel/src/http/span.rs`) in sync when changing shared HTTP field names
+3. Keep `AxumOtelSpanCreator` limited to Axum-specific enrichment such as route, peer address, span name, and span kind
 4. Update documentation with new attributes
 
 ## Dependencies
@@ -309,4 +309,3 @@ This project uses `release-plz` for automated releases. See `release-plz.toml` f
 - [Axum Framework](https://github.com/tokio-rs/axum)
 - [Tower HTTP](https://github.com/tower-rs/tower-http)
 - [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,16 +2212,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry",
- "opentelemetry_sdk",
- "rustversion",
  "smallvec",
- "thiserror",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,5 @@ tower-http = { version = "0.6.6", features = ["trace"] }
 
 tracing = { version = "0.1.44" }
 tracing-appender = { version = "0.2.4" }
-tracing-opentelemetry = { version = "0.32.0" }
+tracing-opentelemetry = { version = "0.32.1" }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/crates/axum-otel/CHANGELOG.md
+++ b/crates/axum-otel/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Delegate shared HTTP server span creation to `tracing-otel-extra`, leaving `AxumOtelSpanCreator` responsible only for Axum-specific enrichment.
 
 ## [0.31.7](https://github.com/nivek-ph/tracing-otel-extra/compare/axum-otel-v0.31.6...axum-otel-v0.31.7)
 
@@ -37,4 +40,4 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/axum-otel/Cargo.toml
+++ b/crates/axum-otel/Cargo.toml
@@ -17,9 +17,8 @@ opentelemetry = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-otel-extra = { workspace = true, features = [
-	"context",
-	"fields",
 	"macros",
+	"span",
 ] }
 
 [dev-dependencies]

--- a/crates/axum-otel/src/make_span.rs
+++ b/crates/axum-otel/src/make_span.rs
@@ -1,28 +1,27 @@
+use std::net::SocketAddr;
+
 use axum::{
     extract::{ConnectInfo, MatchedPath},
     http,
 };
 use opentelemetry::trace::SpanKind;
-use std::net::SocketAddr;
 use tower_http::trace::MakeSpan;
-use tracing::{Level, field::Empty};
-use tracing_otel_extra::{
-    dyn_span,
-    extract::{context, fields},
-};
+use tracing::Level;
+use tracing_otel_extra::http::span::make_request_span;
 
 /// An implementor of [`MakeSpan`] which creates `tracing` spans populated with information about
 /// the request received by an `axum` web server.
 ///
+/// Shared HTTP server span semantics are provided by `tracing-otel-extra`;
+/// this adapter adds only Axum route, peer address, span name, and span kind.
+///
 /// Original implementation from [tower-http](https://github.com/tower-rs/tower-http/blob/main/tower-http/src/trace/make_span.rs).
 ///
-/// This span creator automatically adds the following attributes to each span:
+/// The shared HTTP span module adds the following attributes when their values
+/// are available:
 ///
 /// - `http.request.method`: The HTTP method
-/// - `http.route`: The matched route
-/// - `http.response.status_code`: The response status code (recorded when the response is sent)
 /// - `server.address`: The `Host` header (OpenTelemetry [`server.address`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/server/))
-/// - `client.address`: The client IP when [`ConnectInfo`] is available (OpenTelemetry [`client.address`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/client/))
 /// - `network.protocol.name`: The network protocol name
 /// - `network.protocol.version`: The network protocol version
 /// - `url.path`: The request path
@@ -31,6 +30,13 @@ use tracing_otel_extra::{
 /// - `user_agent.original`: The `User-Agent` header
 /// - `request_id`: A unique request identifier
 /// - `trace_id`: The OpenTelemetry trace ID
+///
+/// This Axum adapter additionally records:
+///
+/// - `http.route`: The matched route
+/// - `client.address`: The client IP when [`ConnectInfo`] is available (OpenTelemetry [`client.address`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/client/))
+/// - `otel.name`: The span name derived from the method and matched route
+/// - `otel.kind`: OpenTelemetry server span kind
 ///
 /// # Example
 ///
@@ -89,54 +95,15 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             |route| format!("{http_method} {route}"),
         );
 
-        let span = dyn_span!(
-            self.level,
-            "request",
-            client.address = Empty,
-            http.request.method = %fields::extract_http_method(request),
-            http.route = Empty,
-            http.response.status_code = Empty,
-            network.protocol.name = fields::extract_network_protocol_name(request),
-            network.protocol.version = Empty,
-            otel.name = span_name,
-            otel.kind = ?SpanKind::Server,
-            otel.status_code = Empty,
-            otel.status_description = Empty,
-            request_id = Empty,
-            server.address = Empty,
-            trace_id = Empty,
-            url.path = fields::extract_url_path(request),
-            url.query = Empty,
-            url.scheme = Empty,
-            user_agent.original = Empty
-        );
-
-        if let Some(host) = fields::extract_host(request) {
-            span.record("server.address", host);
-        }
-        if let Some(route) = http_route {
-            span.record("http.route", route);
-        }
-        if let Some(user_agent) = fields::extract_user_agent(request) {
-            span.record("user_agent.original", user_agent);
-        }
-        if let Some(version) = fields::extract_network_protocol_version(request) {
-            span.record("network.protocol.version", version);
-        }
-        if let Some(request_id) = fields::extract_request_id(request) {
-            span.record("request_id", request_id);
-        }
-        if let Some(query) = fields::extract_url_query(request) {
-            span.record("url.query", query);
-        }
-        if let Some(scheme) = fields::extract_url_scheme(request) {
-            span.record("url.scheme", scheme);
-        }
-        if let Some(peer) = peer {
-            span.record("client.address", tracing::field::display(peer.ip()));
-        }
-
-        context::set_otel_parent(request.headers(), &span);
-        span
+        make_request_span(self.level, request, |span| {
+            span.record("otel.name", span_name.as_str());
+            span.record("otel.kind", tracing::field::debug(SpanKind::Server));
+            if let Some(route) = http_route {
+                span.record("http.route", route);
+            }
+            if let Some(peer) = peer {
+                span.record("client.address", tracing::field::display(peer.ip()));
+            }
+        })
     }
 }

--- a/crates/axum-otel/tests/integration.rs
+++ b/crates/axum-otel/tests/integration.rs
@@ -1,17 +1,25 @@
+use std::{
+    net::SocketAddr,
+    sync::{Mutex, OnceLock},
+};
+
 use axum::{
     Router,
     body::Body,
+    extract::ConnectInfo,
     http::{Method, Request, StatusCode},
     routing::get,
 };
 use axum_otel::{AxumOtelOnFailure, AxumOtelOnResponse, AxumOtelSpanCreator, Level};
 use http_body_util::BodyExt;
-use opentelemetry::{global, trace::TracerProvider};
+use opentelemetry::{
+    global,
+    trace::{SpanKind, TracerProvider},
+};
 use opentelemetry_sdk::{
     Resource,
     trace::{InMemorySpanExporter, RandomIdGenerator, Sampler, SdkTracerProvider},
 };
-use std::sync::{Mutex, OnceLock};
 use tower::ServiceExt;
 use tower_http::trace::TraceLayer;
 use tracing::instrument;
@@ -41,7 +49,7 @@ fn span_attr(span: &opentelemetry_sdk::trace::SpanData, key: &str) -> Option<Str
 }
 
 fn app() -> Router<()> {
-    Router::new().route("/", get(hello)).layer(
+    Router::new().route("/", get(hello)).route_layer(
         TraceLayer::new_for_http()
             .make_span_with(AxumOtelSpanCreator::new().level(Level::INFO))
             .on_response(AxumOtelOnResponse::new().level(Level::INFO))
@@ -73,19 +81,18 @@ async fn test_axum_otel_middleware() {
     let app = app();
 
     // Send request using oneshot
-    let response = app
-        .oneshot(
-            Request::builder()
-                .uri("/?foo=bar")
-                .header("host", "example.com")
-                .header("user-agent", "integration-test")
-                .header("x-forwarded-proto", "https")
-                .method(Method::GET)
-                .body(Body::empty())
-                .expect("Failed to build request"),
-        )
-        .await
-        .expect("Failed to send request");
+    let mut request = Request::builder()
+        .uri("/?foo=bar")
+        .header("host", "example.com")
+        .header("user-agent", "integration-test")
+        .header("x-forwarded-proto", "https")
+        .method(Method::GET)
+        .body(Body::empty())
+        .expect("Failed to build request");
+    request
+        .extensions_mut()
+        .insert(ConnectInfo(SocketAddr::from(([192, 0, 2, 10], 3000))));
+    let response = app.oneshot(request).await.expect("Failed to send request");
 
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -110,11 +117,9 @@ async fn test_axum_otel_middleware() {
         "Expected at least one span to be created"
     );
 
-    // With oneshot(), there's no MatchedPath, so span name is just "GET"
-    // When using a real server, it would be "GET /"
     let request_span = spans
         .iter()
-        .find(|s| s.name == "GET" || s.name == "GET /")
+        .find(|s| s.name == "GET /")
         .expect("Request span not found");
 
     let hello_span = spans
@@ -127,76 +132,27 @@ async fn test_axum_otel_middleware() {
         request_span.span_context.span_id(),
         "Handler span should be a child of the request span"
     );
-
+    assert_eq!(request_span.span_kind, SpanKind::Server);
     assert_eq!(
-        span_attr(request_span, "server.address"),
-        Some("example.com".to_string()),
-        "Expected server.address to be example.com"
+        span_attr(request_span, "http.route"),
+        Some("/".to_string()),
+        "Expected http.route to be /"
     );
+    assert_eq!(
+        span_attr(request_span, "client.address"),
+        Some("192.0.2.10".to_string()),
+        "Expected client.address to be 192.0.2.10"
+    );
+
     assert_eq!(
         span_attr(request_span, "http.request.method"),
         Some("GET".to_string()),
         "Expected http.request.method to be GET"
     );
     assert_eq!(
-        span_attr(request_span, "user_agent.original"),
-        Some("integration-test".to_string()),
-        "Expected user_agent.original to be integration-test"
-    );
-    assert_eq!(
         span_attr(request_span, "http.response.status_code"),
         Some("200".to_string()),
         "Expected http.response.status_code to be 200"
-    );
-    assert_eq!(
-        span_attr(request_span, "url.path"),
-        Some("/".to_string()),
-        "Expected url.path to be /"
-    );
-    assert_eq!(
-        span_attr(request_span, "url.scheme"),
-        Some("https".to_string()),
-        "Expected url.scheme to be https"
-    );
-    assert_eq!(
-        span_attr(request_span, "url.query"),
-        Some("foo=bar".to_string()),
-        "Expected url.query to be foo=bar"
-    );
-    assert_eq!(
-        span_attr(request_span, "network.protocol.name"),
-        Some("http".to_string()),
-        "Expected network.protocol.name to be http"
-    );
-    assert_eq!(
-        span_attr(request_span, "network.protocol.version"),
-        Some("1.1".to_string()),
-        "Expected network.protocol.version to be 1.1"
-    );
-    assert_eq!(
-        span_attr(request_span, "http.method"),
-        None,
-        "Expected deprecated http.method to be absent"
-    );
-    assert_eq!(
-        span_attr(request_span, "http.status_code"),
-        None,
-        "Expected deprecated http.status_code to be absent"
-    );
-    assert_eq!(
-        span_attr(request_span, "http.target"),
-        None,
-        "Expected deprecated http.target to be absent"
-    );
-    assert_eq!(
-        span_attr(request_span, "http.host"),
-        None,
-        "Expected deprecated http.host to be absent"
-    );
-    assert_eq!(
-        span_attr(request_span, "http.user_agent"),
-        None,
-        "Expected deprecated http.user_agent to be absent"
     );
 
     provider
@@ -205,7 +161,7 @@ async fn test_axum_otel_middleware() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn test_axum_otel_omits_missing_optional_fields() {
+async fn test_axum_otel_omits_missing_peer() {
     let _test_guard = test_lock().lock().expect("test lock poisoned");
 
     let exporter = InMemorySpanExporter::default();
@@ -252,28 +208,13 @@ async fn test_axum_otel_omits_missing_optional_fields() {
 
     let request_span = spans
         .iter()
-        .find(|s| s.name == "GET" || s.name == "GET /")
+        .find(|s| s.name == "GET /")
         .expect("Request span not found");
 
     assert_eq!(
-        span_attr(request_span, "server.address"),
+        span_attr(request_span, "client.address"),
         None,
-        "Expected server.address to be omitted when missing"
-    );
-    assert_eq!(
-        span_attr(request_span, "user_agent.original"),
-        None,
-        "Expected user_agent.original to be omitted when missing"
-    );
-    assert_eq!(
-        span_attr(request_span, "url.query"),
-        None,
-        "Expected url.query to be omitted when missing"
-    );
-    assert_eq!(
-        span_attr(request_span, "url.scheme"),
-        None,
-        "Expected url.scheme to be omitted when missing"
+        "Expected client.address to be omitted when missing"
     );
 
     provider

--- a/crates/tracing-otel/CHANGELOG.md
+++ b/crates/tracing-otel/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- Change `make_request_span` to accept a customization callback that runs before remote parent context is applied.
 
 ## [0.31.8](https://github.com/nivek-ph/tracing-otel-extra/compare/tracing-otel-extra-v0.31.7...tracing-otel-extra-v0.31.8)
 

--- a/crates/tracing-otel/Cargo.toml
+++ b/crates/tracing-otel/Cargo.toml
@@ -64,7 +64,7 @@ config = { workspace = true, optional = true }
 opentelemetry = { workspace = true }
 opentelemetry-http = { workspace = true }
 opentelemetry-otlp = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 serial_test = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tracing-otel/README.md
+++ b/crates/tracing-otel/README.md
@@ -15,7 +15,7 @@ A tracing and OpenTelemetry integration utility library for Rust applications, p
 - **Built-in Metrics Support** - Integrated OpenTelemetry metrics collection and export
 - **Environment Detection** - Automatic detection of operating system and process information
 - **OTLP Export** - Built-in OTLP protocol support, can directly export to Jaeger, OTEL Collector, etc.
-- **HTTP request spans** (with `http` + `span` features) - [`make_request_span`](https://docs.rs/tracing-otel-extra/latest/tracing_otel_extra/http/span/fn.make_request_span.html) uses OpenTelemetry-aligned attribute names; see the [`http::span`](https://docs.rs/tracing-otel-extra/latest/tracing_otel_extra/http/span/index.html) module and [`axum-otel`](https://docs.rs/axum-otel) for migration notes.
+- **HTTP request spans** (with `http` + `span` features) - [`make_request_span`](https://docs.rs/tracing-otel-extra/latest/tracing_otel_extra/http/span/fn.make_request_span.html) uses OpenTelemetry-aligned attribute names and supports framework-specific customization before parent context is applied; see the [`http::span`](https://docs.rs/tracing-otel-extra/latest/tracing_otel_extra/http/span/index.html) module and [`axum-otel`](https://docs.rs/axum-otel) for migration notes.
 
 ## Crate Scope
 

--- a/crates/tracing-otel/src/http/span.rs
+++ b/crates/tracing-otel/src/http/span.rs
@@ -11,12 +11,40 @@ use crate::{
 use http::Request;
 use tracing::{Level, Span, field::Empty};
 
-/// Creates a new [`Span`] for the given request.
-pub fn make_request_span<B>(level: Level, request: &Request<B>) -> Span {
+/// Creates a new [`Span`] and customizes it before applying the remote parent.
+///
+/// The `customize_span` callback runs synchronously exactly once after common
+/// HTTP fields are recorded and before the parent context is applied.
+/// Adapter-owned `otel.name` and `otel.kind` values must be recorded in this
+/// callback because they cannot be changed after the OpenTelemetry span is
+/// materialized.
+///
+/// # Example
+///
+/// ```rust
+/// use http::Request;
+/// use tracing::Level;
+/// use tracing_otel_extra::http::span::make_request_span;
+///
+/// let request = Request::builder().uri("/items").body(()).unwrap();
+/// let _span = make_request_span(Level::INFO, &request, |span| {
+///     span.record("http.route", "/items");
+/// });
+/// ```
+///
+/// # Panics
+///
+/// Panics if the `customize_span` callback panics.
+pub fn make_request_span<B>(
+    level: Level,
+    request: &Request<B>,
+    customize_span: impl FnOnce(&Span),
+) -> Span {
     let span = dyn_span!(
         level,
         "request",
         // HTTP fields
+        client.address = Empty,
         http.request.method = %fields::extract_http_method(request),
         http.route = Empty,
         http.response.status_code = Empty,
@@ -56,6 +84,205 @@ pub fn make_request_span<B>(level: Level, request: &Request<B>) -> Span {
         span.record("url.scheme", scheme);
     }
 
+    customize_span(&span);
     context::set_otel_parent(request.headers(), &span);
     span
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::{Method, Version};
+    use opentelemetry::{
+        global,
+        trace::{SpanKind, TracerProvider as _},
+    };
+    use opentelemetry_sdk::{
+        Resource,
+        propagation::TraceContextPropagator,
+        trace::{InMemorySpanExporter, Sampler, SdkTracerProvider},
+    };
+    use tracing::field;
+    use tracing_subscriber::{Registry, layer::SubscriberExt as _};
+
+    fn span_attr(span: &opentelemetry_sdk::trace::SpanData, key: &str) -> Option<String> {
+        span.attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == key)
+            .map(|kv| {
+                let value = kv.value.to_string();
+                value
+                    .strip_prefix('"')
+                    .and_then(|unquoted| unquoted.strip_suffix('"'))
+                    .unwrap_or(&value)
+                    .to_string()
+            })
+    }
+
+    fn export_request_span(request: Request<()>) -> opentelemetry_sdk::trace::SpanData {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOn)
+            .with_simple_exporter(exporter.clone())
+            .with_resource(Resource::builder().build())
+            .build();
+
+        let tracer = provider.tracer("http-span-test");
+        let subscriber =
+            Registry::default().with(tracing_opentelemetry::OpenTelemetryLayer::new(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            make_request_span(Level::INFO, &request, |_| {});
+        });
+
+        provider.force_flush().expect("spans should flush");
+        let request_span = exporter
+            .get_finished_spans()
+            .expect("finished spans should be available")
+            .into_iter()
+            .find(|span| span.name == "request")
+            .expect("request span should be exported");
+
+        provider.shutdown().expect("provider should shut down");
+        request_span
+    }
+
+    #[test]
+    fn request_span_records_shared_http_fields() {
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/items?kind=test")
+            .version(Version::HTTP_2)
+            .header("host", "example.com")
+            .header("user-agent", "span-test")
+            .header("x-request-id", "request-123")
+            .body(())
+            .expect("request should be valid");
+        let request_span = export_request_span(request);
+
+        let expected = [
+            ("http.request.method", "POST"),
+            ("server.address", "example.com"),
+            ("network.protocol.name", "http"),
+            ("network.protocol.version", "2"),
+            ("url.path", "/items"),
+            ("url.query", "kind=test"),
+            ("url.scheme", "https"),
+            ("user_agent.original", "span-test"),
+            ("request_id", "request-123"),
+        ];
+        for (key, value) in expected {
+            assert_eq!(
+                span_attr(&request_span, key),
+                Some(value.to_string()),
+                "{key}"
+            );
+        }
+
+        for deprecated in [
+            "http.method",
+            "http.status_code",
+            "http.target",
+            "http.host",
+            "http.user_agent",
+        ] {
+            assert_eq!(span_attr(&request_span, deprecated), None, "{deprecated}");
+        }
+    }
+
+    #[test]
+    fn request_span_omits_missing_optional_fields() {
+        let request = Request::builder()
+            .uri("/items")
+            .body(())
+            .expect("request should be valid");
+        let request_span = export_request_span(request);
+
+        for missing in [
+            "client.address",
+            "http.route",
+            "server.address",
+            "url.query",
+            "url.scheme",
+            "user_agent.original",
+            "request_id",
+        ] {
+            assert_eq!(span_attr(&request_span, missing), None, "{missing}");
+        }
+        assert_eq!(
+            span_attr(&request_span, "network.protocol.version"),
+            Some("1.1".to_string())
+        );
+    }
+
+    #[test]
+    fn request_span_inherits_remote_parent() {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let trace_id = "4bf92f3577b34da6a3ce929d0e0e4736";
+        let parent_span_id = "00f067aa0ba902b7";
+        let request = Request::builder()
+            .uri("/items")
+            .header("traceparent", format!("00-{trace_id}-{parent_span_id}-01"))
+            .body(())
+            .expect("request should be valid");
+        let request_span = export_request_span(request);
+
+        assert_eq!(request_span.span_context.trace_id().to_string(), trace_id);
+        assert_eq!(request_span.parent_span_id.to_string(), parent_span_id);
+        assert_eq!(
+            span_attr(&request_span, "trace_id"),
+            Some(trace_id.to_string())
+        );
+    }
+
+    #[test]
+    fn adapter_customization_runs_before_parent_materializes_span() {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let trace_id = "4bf92f3577b34da6a3ce929d0e0e4736";
+        let request = Request::builder()
+            .uri("/items")
+            .header("traceparent", format!("00-{trace_id}-00f067aa0ba902b7-01"))
+            .body(())
+            .expect("request should be valid");
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOn)
+            .with_simple_exporter(exporter.clone())
+            .with_resource(Resource::builder().build())
+            .build();
+        let tracer = provider.tracer("http-span-customization-test");
+        let subscriber =
+            Registry::default().with(tracing_opentelemetry::OpenTelemetryLayer::new(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            make_request_span(Level::INFO, &request, |span| {
+                span.record("http.route", "/items");
+                span.record("client.address", field::display("192.0.2.1"));
+                span.record("otel.name", "GET /items");
+                span.record("otel.kind", field::debug(SpanKind::Server));
+            });
+        });
+
+        provider.force_flush().expect("spans should flush");
+        let request_span = exporter
+            .get_finished_spans()
+            .expect("finished spans should be available")
+            .into_iter()
+            .find(|span| span.name == "GET /items")
+            .expect("customized request span should be exported");
+
+        assert_eq!(request_span.span_kind, SpanKind::Server);
+        assert_eq!(
+            span_attr(&request_span, "http.route"),
+            Some("/items".to_string())
+        );
+        assert_eq!(
+            span_attr(&request_span, "client.address"),
+            Some("192.0.2.1".to_string())
+        );
+        assert_eq!(request_span.span_context.trace_id().to_string(), trace_id);
+
+        provider.shutdown().expect("provider should shut down");
+    }
 }


### PR DESCRIPTION
## Summary
- Change `make_request_span` to take a customization callback that runs before remote parent context is applied (breaking for `span` feature callers).
- Thin `AxumOtelSpanCreator` so it only records Axum-specific fields (`http.route`, `client.address`, `otel.name`, `otel.kind`) via that callback.
- Add unit coverage for shared HTTP span fields and tighten Axum integration tests around matched route / peer address.

## Test plan
- [ ] `cargo test -p tracing-otel-extra --features "span"`
- [ ] `cargo test -p axum-otel`
- [ ] Confirm callers of `make_request_span` updated for the new callback signature