### PR TITLE
refactor: introduce LoggerGuard for owned OTel + file writer shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,20 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-            ${{ runner.os }}-cargo-
       - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: "v0.10.0"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Clippy
         run: cargo clippy --all-features -- -D warnings
 
@@ -46,20 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-            ${{ runner.os }}-cargo-
       - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: "v0.10.0"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Run tests
         run: cargo test --all-features
       - name: Run doc tests
@@ -74,16 +58,9 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.MSRV }}
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-msrv-
+          cache-on-failure: true
       - name: Check MSRV
         run: cargo check --all-features
 

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ let _guard = Logger::new("service")
 
 - `Logger` - Main configuration builder
 - `LogFormat` - Log output format options
-- `ProviderGuard` - RAII resource management
+- `LoggerGuard` - RAII ownership for telemetry providers and non-blocking writer shutdown
 
 ### tracing-opentelemetry-extra
 

--- a/crates/tracing-opentelemetry/CHANGELOG.md
+++ b/crates/tracing-opentelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- Remove `Clone` from `OtelGuard` so dropping a duplicate cannot shut down shared OpenTelemetry providers early.
 
 ## [0.31.8](https://github.com/nivek-ph/tracing-otel-extra/compare/tracing-opentelemetry-extra-v0.31.7...tracing-opentelemetry-extra-v0.31.8)
 

--- a/crates/tracing-opentelemetry/src/guard.rs
+++ b/crates/tracing-opentelemetry/src/guard.rs
@@ -4,8 +4,17 @@ use opentelemetry_sdk::{
 };
 use tracing::warn;
 
-/// A guard that holds the tracer provider, meter provider, and logger provider and ensures proper cleanup
-#[derive(Debug, Clone)]
+/// A guard that holds the tracer provider, meter provider, and logger provider and ensures proper cleanup.
+///
+/// The guard has unique ownership of provider shutdown and cannot be cloned.
+///
+/// ```compile_fail
+/// use tracing_opentelemetry_extra::OtelGuard;
+///
+/// let guard = OtelGuard::new(None, None, None);
+/// let _duplicate = guard.clone();
+/// ```
+#[derive(Debug)]
 pub struct OtelGuard {
     tracer_provider: Option<SdkTracerProvider>,
     meter_provider: Option<SdkMeterProvider>,

--- a/crates/tracing-otel/CHANGELOG.md
+++ b/crates/tracing-otel/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### ⚠️ Breaking Changes
 
 - Change `make_request_span` to accept a customization callback that runs before remote parent context is applied.
-- Return `LoggerGuard` from `Logger::init`, `init_logging`, and `init_logging_from_env`; output-layer construction is now internal so writer ownership cannot escape the returned guard.
+- Return `LoggerGuard` from `Logger::init`, `init_logging`, and `init_logging_from_env`.
+- Remove the public `logger::create_output_layers` and `logger::set_nonblocking_appender_guard` APIs so writer ownership cannot escape the returned guard. Applications should initialize logging through `Logger::init`, `init_logging`, or `init_logging_from_env` and retain the returned `LoggerGuard` for the lifetime of logging.
 
 ### 🐛 Bug Fixes
 

--- a/crates/tracing-otel/CHANGELOG.md
+++ b/crates/tracing-otel/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### ⚠️ Breaking Changes
 
 - Change `make_request_span` to accept a customization callback that runs before remote parent context is applied.
+- Return `LoggerGuard` from `Logger::init`, `init_logging`, and `init_logging_from_env`; output-layer construction is now internal so writer ownership cannot escape the returned guard.
+
+### 🐛 Bug Fixes
+
+- Keep the non-blocking file writer guard in `LoggerGuard` so dropping or shutting down the logger triggers tracing-appender's writer shutdown and flush path instead of leaving the guard in a process-level `OnceLock`; the writer does not report the flush outcome.
 
 ## [0.31.8](https://github.com/nivek-ph/tracing-otel-extra/compare/tracing-otel-extra-v0.31.7...tracing-otel-extra-v0.31.8)
 

--- a/crates/tracing-otel/README.md
+++ b/crates/tracing-otel/README.md
@@ -192,7 +192,7 @@ async fn health_check() -> &'static str {
 
 ## Resource Cleanup
 
-`ProviderGuard` implements the RAII pattern and automatically cleans up OpenTelemetry resources when the guard goes out of scope:
+`LoggerGuard` implements the RAII pattern and automatically shuts down OpenTelemetry providers, then releases non-blocking file writer guards to trigger their shutdown and flush path. The writer does not report the flush outcome:
 
 ```rust
 {

--- a/crates/tracing-otel/src/lib.rs
+++ b/crates/tracing-otel/src/lib.rs
@@ -84,7 +84,7 @@ pub use otel::*;
 // Logger module exports
 #[cfg(feature = "logger")]
 pub use logger::{
-    FmtSpan, LogFormat, LogRollingRotation, Logger, LoggerFileAppender, init_logging,
+    FmtSpan, LogFormat, LogRollingRotation, Logger, LoggerFileAppender, LoggerGuard, init_logging,
 };
 
 // Logger module exports

--- a/crates/tracing-otel/src/logger/config.rs
+++ b/crates/tracing-otel/src/logger/config.rs
@@ -11,8 +11,8 @@ use super::deserialize::{
     default, deserialize_attributes, deserialize_level_optional, deserialize_level_required,
     deserialize_log_format, deserialize_log_format_optional, deserialize_span_events,
 };
+use super::guard::LoggerGuard;
 use super::init::init_tracing_from_logger;
-use crate::otel::OtelGuard;
 
 #[cfg(feature = "env")]
 use super::env::init_logger_from_env;
@@ -299,7 +299,7 @@ impl Logger {
     }
 
     /// Initialize tracing with this configuration.
-    pub fn init(self) -> Result<OtelGuard> {
+    pub fn init(self) -> Result<LoggerGuard> {
         init_tracing_from_logger(self)
     }
 

--- a/crates/tracing-otel/src/logger/env.rs
+++ b/crates/tracing-otel/src/logger/env.rs
@@ -4,8 +4,8 @@ use anyhow::{Context, Result};
 use config::{Config, Environment};
 
 use super::config::{Logger, LoggerFileAppender};
+use super::guard::LoggerGuard;
 use super::init::init_tracing_from_logger;
-use crate::otel::OtelGuard;
 
 /// Initialize a Logger from environment variables
 pub fn init_logger_from_env(prefix: Option<&str>) -> Result<Logger> {
@@ -26,7 +26,7 @@ pub fn init_logger_from_env(prefix: Option<&str>) -> Result<Logger> {
 }
 
 /// Initialize tracing from environment variables
-pub fn init_logging_from_env(prefix: Option<&str>) -> Result<OtelGuard> {
+pub fn init_logging_from_env(prefix: Option<&str>) -> Result<LoggerGuard> {
     let logger = init_logger_from_env(prefix)?;
     init_tracing_from_logger(logger)
 }

--- a/crates/tracing-otel/src/logger/guard.rs
+++ b/crates/tracing-otel/src/logger/guard.rs
@@ -1,0 +1,148 @@
+//! Runtime ownership for initialized logging resources.
+
+use crate::otel::OtelGuard;
+use anyhow::Result;
+use tracing_appender::non_blocking::WorkerGuard;
+
+/// Owns the OpenTelemetry providers and non-blocking log writers initialized by [`super::Logger`].
+#[derive(Debug)]
+pub struct LoggerGuard {
+    otel_guard: OtelGuard,
+    worker_guard: Option<WorkerGuard>,
+}
+
+impl LoggerGuard {
+    pub(crate) fn new(otel_guard: OtelGuard, worker_guard: Option<WorkerGuard>) -> Self {
+        Self {
+            otel_guard,
+            worker_guard,
+        }
+    }
+
+    /// Shut down the OpenTelemetry providers, then release the file writer guard.
+    ///
+    /// Releasing the writer guard triggers tracing-appender's shutdown and flush
+    /// path, which does not report its outcome to the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any OpenTelemetry provider fails to shut down. Log
+    /// writers are still released after the shutdown attempt.
+    pub fn shutdown(self) -> Result<()> {
+        let result = self.otel_guard.shutdown();
+        drop(self.worker_guard);
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        io::Write,
+        path::Path,
+        sync::mpsc::{self, Sender},
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
+    const LOG_MARKER: &str = "logger-guard-flush-marker";
+    const LOG_RECORDS: usize = 256;
+
+    struct DropProbe(Sender<()>);
+
+    impl Write for DropProbe {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
+    }
+
+    #[test]
+    fn dropping_logger_guard_releases_file_writer() {
+        let (guard, _writer, writer_dropped) = logger_guard_with_drop_probe();
+
+        drop(guard);
+
+        writer_dropped
+            .recv_timeout(Duration::from_secs(1))
+            .expect("file writer should be released with logger guard");
+    }
+
+    #[test]
+    fn shutdown_releases_file_writer() {
+        let (guard, _writer, writer_dropped) = logger_guard_with_drop_probe();
+
+        guard.shutdown().expect("providers should shut down");
+
+        writer_dropped
+            .recv_timeout(Duration::from_secs(1))
+            .expect("file writer should be released after shutdown");
+    }
+
+    #[test]
+    fn dropping_logger_guard_flushes_non_blocking_file_logs() -> anyhow::Result<()> {
+        let log_dir = create_tmp_log_dir();
+        fs::create_dir_all(&log_dir)?;
+        let file_appender = tracing_appender::rolling::never(&log_dir, "logger-guard.log");
+        let (writer, worker_guard) = tracing_appender::non_blocking(file_appender);
+        let guard = LoggerGuard::new(OtelGuard::new(None, None, None), Some(worker_guard));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_writer(writer)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, move || {
+            for index in 0..LOG_RECORDS {
+                tracing::info!("{LOG_MARKER}-{index:03}|");
+            }
+            drop(guard);
+        });
+
+        let logs = read_logs(&log_dir)?;
+        for index in 0..LOG_RECORDS {
+            let record = format!("{LOG_MARKER}-{index:03}|");
+            assert!(logs.contains(&record), "missing {record:?}");
+        }
+        assert_eq!(logs.matches(LOG_MARKER).count(), LOG_RECORDS);
+
+        fs::remove_dir_all(log_dir)?;
+        Ok(())
+    }
+
+    fn logger_guard_with_drop_probe() -> (
+        LoggerGuard,
+        tracing_appender::non_blocking::NonBlocking,
+        mpsc::Receiver<()>,
+    ) {
+        let (writer_dropped, receiver) = mpsc::channel();
+        let (writer, worker_guard) = tracing_appender::non_blocking(DropProbe(writer_dropped));
+        let guard = LoggerGuard::new(OtelGuard::new(None, None, None), Some(worker_guard));
+        (guard, writer, receiver)
+    }
+
+    fn create_tmp_log_dir() -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("tracing-otel-extra-{}-{nonce}", std::process::id()))
+    }
+
+    fn read_logs(log_dir: &Path) -> std::io::Result<String> {
+        let mut logs = String::new();
+        for entry in fs::read_dir(log_dir)? {
+            logs.push_str(&fs::read_to_string(entry?.path())?);
+        }
+        Ok(logs)
+    }
+}

--- a/crates/tracing-otel/src/logger/guard.rs
+++ b/crates/tracing-otel/src/logger/guard.rs
@@ -7,6 +7,8 @@ use tracing_appender::non_blocking::WorkerGuard;
 /// Owns the OpenTelemetry providers and non-blocking log writers initialized by [`super::Logger`].
 #[derive(Debug)]
 pub struct LoggerGuard {
+    // Field order is intentional: Rust drops fields in declaration order. Keep the provider
+    // guard first so shutdown diagnostics can be flushed before the writer guard is released.
     otel_guard: OtelGuard,
     worker_guard: Option<WorkerGuard>,
 }
@@ -91,8 +93,17 @@ mod tests {
 
     #[test]
     fn dropping_logger_guard_flushes_non_blocking_file_logs() -> anyhow::Result<()> {
+        struct TempDirGuard(std::path::PathBuf);
+
+        impl Drop for TempDirGuard {
+            fn drop(&mut self) {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+
         let log_dir = create_tmp_log_dir();
         fs::create_dir_all(&log_dir)?;
+        let _cleanup = TempDirGuard(log_dir.clone());
         let file_appender = tracing_appender::rolling::never(&log_dir, "logger-guard.log");
         let (writer, worker_guard) = tracing_appender::non_blocking(file_appender);
         let guard = LoggerGuard::new(OtelGuard::new(None, None, None), Some(worker_guard));
@@ -115,7 +126,6 @@ mod tests {
         }
         assert_eq!(logs.matches(LOG_MARKER).count(), LOG_RECORDS);
 
-        fs::remove_dir_all(log_dir)?;
         Ok(())
     }
 

--- a/crates/tracing-otel/src/logger/guard.rs
+++ b/crates/tracing-otel/src/logger/guard.rs
@@ -1,10 +1,28 @@
 //! Runtime ownership for initialized logging resources.
 
-use crate::otel::OtelGuard;
 use anyhow::Result;
 use tracing_appender::non_blocking::WorkerGuard;
 
+use crate::otel::OtelGuard;
+
 /// Owns the OpenTelemetry providers and non-blocking log writers initialized by [`super::Logger`].
+///
+/// Keep this guard alive for as long as logging is needed. Dropping it performs automatic
+/// cleanup, or call [`Self::shutdown`] to handle OpenTelemetry shutdown errors explicitly.
+///
+/// # Examples
+///
+/// ```no_run
+/// use tracing_otel_extra::Logger;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let guard = Logger::new("my-service").init()?;
+///
+/// // Run the application while `guard` remains in scope.
+/// guard.shutdown()?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct LoggerGuard {
     // Field order is intentional: Rust drops fields in declaration order. Keep the provider

--- a/crates/tracing-otel/src/logger/init.rs
+++ b/crates/tracing-otel/src/logger/init.rs
@@ -1,15 +1,20 @@
 //! Logger initialization functions.
 
-use crate::otel::OtelGuard;
 use anyhow::{Context, Result};
 
 use super::config::Logger;
-use super::subscriber::{create_output_layers, setup_tracing};
+use super::{
+    guard::LoggerGuard,
+    subscriber::{OutputLayers, create_output_layers, setup_tracing},
+};
 
 /// Initialize tracing from a Logger configuration
-pub fn init_tracing_from_logger(logger: Logger) -> Result<OtelGuard> {
-    let layers = create_output_layers(&logger)?;
-    let guard = setup_tracing(
+pub fn init_tracing_from_logger(logger: Logger) -> Result<LoggerGuard> {
+    let OutputLayers {
+        layers,
+        worker_guard,
+    } = create_output_layers(&logger)?;
+    let otel_guard = setup_tracing(
         &logger.service_name,
         &logger.attributes,
         logger.sample_ratio,
@@ -19,11 +24,11 @@ pub fn init_tracing_from_logger(logger: Logger) -> Result<OtelGuard> {
         logger.otel_logs_enabled,
     )
     .context("Failed to initialize tracing")?;
-    Ok(guard)
+    Ok(LoggerGuard::new(otel_guard, worker_guard))
 }
 
 /// Convenience function to initialize tracing with default settings
-pub fn init_logging(service_name: &str) -> Result<OtelGuard> {
+pub fn init_logging(service_name: &str) -> Result<LoggerGuard> {
     let logger = Logger::new(service_name);
     init_tracing_from_logger(logger)
 }

--- a/crates/tracing-otel/src/logger/mod.rs
+++ b/crates/tracing-otel/src/logger/mod.rs
@@ -62,6 +62,7 @@ mod config;
 mod deserialize;
 #[cfg(feature = "env")]
 mod env;
+mod guard;
 mod init;
 mod subscriber;
 
@@ -70,6 +71,7 @@ pub use config::{LogFormat, LogRollingRotation, Logger, LoggerFileAppender};
 pub use deserialize::default;
 #[cfg(feature = "env")]
 pub use env::{init_logger_from_env, init_logging_from_env};
+pub use guard::LoggerGuard;
 pub use init::{init_logging, init_tracing_from_logger};
 pub use subscriber::*;
 

--- a/crates/tracing-otel/src/logger/subscriber.rs
+++ b/crates/tracing-otel/src/logger/subscriber.rs
@@ -7,8 +7,7 @@ use crate::{
         init_tracing_subscriber, opentelemetry::KeyValue,
     },
 };
-use anyhow::{Context, Result, anyhow};
-use std::sync::OnceLock;
+use anyhow::{Context, Result};
 use tracing::Level;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_opentelemetry_extra::BoxLayer;
@@ -17,13 +16,9 @@ use tracing_subscriber::{
     fmt::{self, MakeWriter, format::FmtSpan},
 };
 
-// Keep non-blocking appender worker guard to prevent log loss
-static NONBLOCKING_APPENDER_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
-
-pub fn set_nonblocking_appender_guard(guard: WorkerGuard) -> Result<()> {
-    NONBLOCKING_APPENDER_GUARD
-        .set(guard)
-        .map_err(|_| anyhow!("cannot lock for appender"))
+pub(crate) struct OutputLayers {
+    pub(crate) layers: Vec<BoxLayer>,
+    pub(crate) worker_guard: Option<WorkerGuard>,
 }
 
 /// Creates an environment filter for tracing based on the given level.
@@ -68,8 +63,9 @@ where
 }
 
 /// Create output layers based on configuration.
-pub fn create_output_layers(logger: &Logger) -> Result<Vec<BoxLayer>> {
+pub(crate) fn create_output_layers(logger: &Logger) -> Result<OutputLayers> {
     let mut layers: Vec<BoxLayer> = vec![];
+    let mut worker_guard = None;
 
     // Add console layer if enabled
     if logger.console_enabled {
@@ -96,9 +92,9 @@ pub fn create_output_layers(logger: &Logger) -> Result<Vec<BoxLayer>> {
             .context("Failed to build file appender")?;
 
         let file_appender_layer = if config.non_blocking {
-            let (non_blocking_file_appender, work_guard) =
+            let (non_blocking_file_appender, non_blocking_worker_guard) =
                 tracing_appender::non_blocking(file_appender);
-            set_nonblocking_appender_guard(work_guard)?;
+            worker_guard = Some(non_blocking_worker_guard);
             init_layer(
                 non_blocking_file_appender,
                 &config.format_or_default(),
@@ -115,7 +111,10 @@ pub fn create_output_layers(logger: &Logger) -> Result<Vec<BoxLayer>> {
         };
         layers.push(file_appender_layer);
     }
-    Ok(layers)
+    Ok(OutputLayers {
+        layers,
+        worker_guard,
+    })
 }
 
 /// Initializes the complete tracing stack with OpenTelemetry integration.


### PR DESCRIPTION
## Summary
- Introduce `LoggerGuard` as the RAII owner returned by `Logger::init`, `init_logging`, and `init_logging_from_env`, bundling `OtelGuard` with the non-blocking file `WorkerGuard`.
- Move the file writer guard out of a process-level `OnceLock` into `LoggerGuard`, so drop/`shutdown()` actually release the appender and trigger tracing-appender's flush path.
- Remove `Clone` from `OtelGuard` to prevent a cloned guard from shutting down shared providers early.
- Modernize the Rust CI jobs to use `Swatinem/rust-cache@v2` instead of manual `actions/cache`; this validation-pipeline maintenance is intentionally included in this PR.

## Breaking changes
- `Logger::init` / `init_logging` / `init_logging_from_env` now return `LoggerGuard` instead of `OtelGuard` (docs previously referred to this as `ProviderGuard`).
- The public `logger::create_output_layers` and `logger::set_nonblocking_appender_guard` APIs are removed. Initialize logging through `Logger::init`, `init_logging`, or `init_logging_from_env`, and retain the returned `LoggerGuard` for the lifetime of logging.
- `OtelGuard` is no longer `Clone`.

## Test plan
- [x] `cargo test -p tracing-otel-extra --features "logger,env"`
- [x] Confirm `LoggerGuard` drop/shutdown tests pass (writer release + non-blocking flush)
- [x] Confirm this repository has no `OtelGuard::clone` callers
- [ ] Smoke an example with file logging enabled and verify logs flush on process exit / guard drop
- [ ] Confirm downstream apps that previously cloned `OtelGuard` update to keep a single owner
