### PR TITLE
feat!: upgrade OpenTelemetry to 0.32 and tracing-opentelemetry to 0.33

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,11 +237,11 @@ mod tests {
 
 | Crate                          | Purpose                         |
 | ------------------------------ | ------------------------------- |
-| `opentelemetry` (0.31)         | Core OpenTelemetry APIs         |
-| `opentelemetry-otlp` (0.31)    | OTLP exporter                   |
+| `opentelemetry` (0.32)         | Core OpenTelemetry APIs         |
+| `opentelemetry-otlp` (0.32)    | OTLP exporter                   |
 | `tracing` (0.1)                | Rust tracing framework          |
 | `tracing-subscriber` (0.3)     | Subscriber implementations      |
-| `tracing-opentelemetry` (0.32) | Bridge between tracing and OTel |
+| `tracing-opentelemetry` (0.33) | Bridge between tracing and OTel |
 | `axum` (0.8)                   | Web framework                   |
 | `tower-http` (0.6)             | HTTP middleware utilities       |
 | `reqwest` (0.13, examples)     | HTTP client in microservices demo |
@@ -251,8 +251,7 @@ mod tests {
 
 ### Version Compatibility Notes
 
-- Examples use `reqwest-tracing` 0.7 with the `opentelemetry_0_31` feature, aligned with workspace OpenTelemetry 0.31.
-- `opentelemetry-otlp` still depends on `reqwest` 0.12 internally; the workspace may resolve both 0.12 and 0.13 until OTLP upgrades.
+- Examples use `reqwest-tracing` 0.7 with the `opentelemetry_0_32` feature, aligned with workspace OpenTelemetry 0.32.
 - Always check compatibility when upgrading OpenTelemetry crates as they often have breaking changes
 
 ## Environment Variables

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "axum",
  "axum-otel",
  "dotenvy",
- "reqwest 0.13.4",
+ "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -238,13 +238,13 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.14.1"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
- "nom",
  "pathdiff",
- "serde",
+ "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -618,7 +618,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -943,12 +942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,16 +950,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1007,9 +990,9 @@ checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1021,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -1033,22 +1016,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1056,19 +1039,19 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "base64",
  "const-hex",
@@ -1076,26 +1059,25 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
- "serde_json",
  "tonic",
  "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand",
  "thiserror",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -1166,6 +1148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1222,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1373,46 +1370,6 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -1420,7 +1377,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1460,7 +1419,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror",
  "tower-service",
 ]
@@ -1477,7 +1436,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http",
  "hyper",
- "reqwest 0.13.4",
+ "reqwest",
  "reqwest-middleware",
  "retry-policies",
  "thiserror",
@@ -1498,7 +1457,7 @@ dependencies = [
  "http",
  "matchit",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
  "reqwest-middleware",
  "tracing",
  "tracing-opentelemetry",
@@ -2104,6 +2063,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -2704,6 +2674,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,21 +41,21 @@ tracing-otel-extra = { path = "crates/tracing-otel", version = "0.32.1" }
 anyhow = "1.0"
 
 axum = { version = "0.8.7" }
-config = { version = "0.14.0", default-features = false }
+config = { version = "0.15.0", default-features = false }
 dotenvy = { version = "0.15.7" }
 http = { version = "1.3.1" }
 http-body-util = { version = "0.1" }
-opentelemetry = { version = "0.31.0", default-features = false }
-opentelemetry-appender-tracing = { version = "0.31.0" }
-opentelemetry-http = { version = "0.31.0", default-features = false }
-opentelemetry-otlp = { version = "0.31.0", features = [
+opentelemetry = { version = "0.32.0", default-features = false }
+opentelemetry-appender-tracing = { version = "0.32.0" }
+opentelemetry-http = { version = "0.32.0", default-features = false }
+opentelemetry-otlp = { version = "0.32.0", features = [
     "grpc-tonic",
     "http-json",
     "http-proto",
     "tls",
     "reqwest-rustls",
 ] }
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
+opentelemetry_sdk = { version = "0.32.0", default-features = false, features = [
     "trace",
     "logs",
 ] }
@@ -64,7 +64,7 @@ opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
 reqwest = { version = "0.13.1", features = ["json"] }
 reqwest-middleware = "0.5.1"
 reqwest-retry = "0.9.1"
-reqwest-tracing = { version = "0.7.0", features = ["opentelemetry_0_31"] }
+reqwest-tracing = { version = "0.7.1", features = ["opentelemetry_0_32"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -77,5 +77,5 @@ tower-http = { version = "0.6.6", features = ["trace"] }
 
 tracing = { version = "0.1.44" }
 tracing-appender = { version = "0.2.4" }
-tracing-opentelemetry = { version = "0.32.1" }
+tracing-opentelemetry = { version = "0.33.0" }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/crates/axum-otel/CHANGELOG.md
+++ b/crates/axum-otel/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- Upgrade OpenTelemetry dependencies to `0.32` and `tracing-opentelemetry` to `0.33`. Downstream crates must use matching OpenTelemetry versions.
+
 ### Changed
 
 - Delegate shared HTTP server span creation to `tracing-otel-extra`, leaving `AxumOtelSpanCreator` responsible only for Axum-specific enrichment.

--- a/crates/tracing-opentelemetry/CHANGELOG.md
+++ b/crates/tracing-opentelemetry/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### ⚠️ Breaking Changes
 
+- Upgrade OpenTelemetry dependencies to `0.32` and `tracing-opentelemetry` to `0.33`. Downstream crates must use matching OpenTelemetry versions.
 - Remove `Clone` from `OtelGuard` so dropping a duplicate cannot shut down shared OpenTelemetry providers early.
 
 ## [0.31.8](https://github.com/nivek-ph/tracing-otel-extra/compare/tracing-opentelemetry-extra-v0.31.7...tracing-opentelemetry-extra-v0.31.8)

--- a/crates/tracing-otel/CHANGELOG.md
+++ b/crates/tracing-otel/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### ⚠️ Breaking Changes
 
+- Upgrade OpenTelemetry dependencies to `0.32` and `tracing-opentelemetry` to `0.33`. Downstream crates must use matching OpenTelemetry versions.
 - Change `make_request_span` to accept a customization callback that runs before remote parent context is applied.
 - Return `LoggerGuard` from `Logger::init`, `init_logging`, and `init_logging_from_env`.
 - Remove the public `logger::create_output_layers` and `logger::set_nonblocking_appender_guard` APIs so writer ownership cannot escape the returned guard. Applications should initialize logging through `Logger::init`, `init_logging`, or `init_logging_from_env` and retain the returned `LoggerGuard` for the lifetime of logging.


### PR DESCRIPTION
## Summary

- Bump the OpenTelemetry stack from `0.31` → `0.32` (`opentelemetry`, `opentelemetry-otlp`, `opentelemetry-http`, `opentelemetry-appender-tracing`, `opentelemetry_sdk`).
- Bump `tracing-opentelemetry` from `0.32` → `0.33`.
- Align examples with `reqwest-tracing` `0.7.1` + `opentelemetry_0_32`.
- Also bump `config` `0.14` → `0.15`.
- Document the breaking dependency upgrade under each crate's `CHANGELOG.md` `[Unreleased]`.

This is a **breaking change** for downstream crates: they must use matching OpenTelemetry / `tracing-opentelemetry` versions.

## Release

After merge, release-plz should open a release PR targeting **v0.33.0** (minor bump for the breaking OTel upgrade). Do not bump crate versions in this PR.

## Test plan

- [x] `cargo run -p axum-otel-demo` starts successfully
- [x] `cargo test --workspace`
- [x] `cargo check -p articles-service -p users-service` (microservices examples)
- [x] Confirm OTLP export still works against a local collector when `OTEL_EXPORTER_OTLP_ENDPOINT` is set