### PR TITLE
chore: release v0.33.1

### DIFF
--- a/crates/axum-otel/CHANGELOG.md
+++ b/crates/axum-otel/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.33.1](https://github.com/nivek-ph/tracing-otel-extra/compare/axum-otel-v0.33.0...axum-otel-v0.33.1)
+
 ### Changed
 
 - Replace the internal `tracing-otel-extra` dependency with its successor, `tracing-otel`. Applications that also depend on the shared tracing crate directly must replace `tracing-otel-extra = "0.33.0"` with `tracing-otel = "0.33.1"` and update Rust imports from `tracing_otel_extra` to `tracing_otel`.

--- a/crates/otel-init/CHANGELOG.md
+++ b/crates/otel-init/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.33.1]
+
 ### Added
 
 - Publish `otel-init` `0.33.1` as the successor to `tracing-opentelemetry-extra` `0.33.0`. These are separate crates.io packages; Cargo does not migrate dependencies automatically.

--- a/crates/tracing-otel/CHANGELOG.md
+++ b/crates/tracing-otel/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.33.1]
+
 ### Added
 
 - Publish `tracing-otel` `0.33.1` as the successor to `tracing-otel-extra` `0.33.0`. These are separate crates.io packages; Cargo does not migrate dependencies automatically.


### PR DESCRIPTION
## Release

Prepare the v0.33.1 releases:

- otel-init: first release, successor to tracing-opentelemetry-extra 0.33.0
- tracing-otel: first release, successor to tracing-otel-extra 0.33.0
- axum-otel: 0.33.0 -> 0.33.1

Merging this PR is the publish gate. Yank the two old 0.33.0 packages only after all three new releases are verified on crates.io.